### PR TITLE
fix: use monitor ID instead of name for event enrichment

### DIFF
--- a/tests/tools/events-async.test.ts
+++ b/tests/tools/events-async.test.ts
@@ -954,13 +954,13 @@ describe('Events V2 API Functions', () => {
       expect(result[0].monitorMetadata).toBeUndefined()
     })
 
-    it('should cache monitors by name', async () => {
+    it('should cache monitors by ID', async () => {
       const events = [
         createMockEventSummary({
-          monitorInfo: { name: 'Monitor A', status: 'triggered', scope: '' }
+          monitorId: 123
         }),
         createMockEventSummary({
-          monitorInfo: { name: 'Monitor A', status: 'triggered', scope: '' }
+          monitorId: 123
         })
       ]
 


### PR DESCRIPTION
## Problem

The `enrich: true` parameter in `mcp__datadog__events` search had no effect. Events were returned without `monitorMetadata` even when enrichment was requested.

### Root Cause

The `enrichWithMonitorMetadata` function relied on `event.monitorInfo?.name`, which is only populated when event titles match the pattern `[Status on {scope}] Monitor Name`. For plain event titles like "High number of ready message in queue", `monitorInfo` was `undefined`, causing the function to early-return without adding any metadata.

## Solution

Changed enrichment to use `event.monitorId` (reliably extracted from message body via regex) instead of `event.monitorInfo?.name`.

**Changes:**
- Extract monitor IDs from events instead of names
- Cache monitors by ID (`Map<number, Monitor>`) instead of name
- Filter API response to only needed monitor IDs
- Look up monitors by `monitorId` instead of `monitorInfo?.name`
- Updated test to reflect ID-based caching

**Note:** The TypeScript client doesn't expose the `monitor_ids` parameter (confirmed via API testing), so we fetch all monitors (pageSize: 1000) and filter in memory.

## Impact

✅ **Fixes enrichment:** `enrich: true` now correctly adds `monitorMetadata` field to all events
✅ **Backward compatible:** Only affects responses when `enrich: true` is used
✅ **N8n workflow:** Will now receive monitor metadata (tags, thresholds, descriptions)

## Testing

- All 903 tests passing ✅
- Updated existing test for ID-based caching
- Manually tested API behavior with production Datadog