### PR TITLE
fix: change maxEvents limit from 10000 to 5000 to match Datadog API

### DIFF
--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -68,10 +68,10 @@ const InputSchema = {
   maxEvents: z
     .number()
     .min(1)
-    .max(10000)
+    .max(5000)
     .optional()
     .describe(
-      'Maximum events to fetch for grouping in top action (default: 10000). Higher = more accurate but slower'
+      'Maximum events to fetch for grouping in top action (default: 5000, max: 5000). Higher = more accurate but slower'
     )
 }
 
@@ -746,7 +746,7 @@ export async function topEventsV2(
   const effectiveTags = params.tags ?? ['source:alert']
 
   // Step 1: Fetch events for accurate grouping
-  // maxEvents controls how many events to fetch (default 10k). Higher values = more accurate
+  // maxEvents controls how many events to fetch (default 5k, max 5k per Datadog API). Higher values = more accurate
   // aggregation but slower performance. If there are more events than maxEvents, results
   // may be incomplete. Narrow time range or use filters (query, tags) if incomplete.
   const result = await searchEventsV2(
@@ -757,7 +757,7 @@ export async function topEventsV2(
       to: params.to,
       sources: params.sources,
       tags: effectiveTags,
-      limit: params.maxEvents ?? 10000
+      limit: params.maxEvents ?? 5000
     },
     limits,
     site

--- a/tests/tools/events-async.test.ts
+++ b/tests/tools/events-async.test.ts
@@ -746,7 +746,7 @@ describe('Events V2 API Functions', () => {
       })
     })
 
-    it('should use default maxEvents of 10000', async () => {
+    it('should use default maxEvents of 5000', async () => {
       const mockApi = {
         searchEvents: vi.fn().mockResolvedValue({ data: [], meta: { page: {} } })
       } as unknown as v2.EventsApi
@@ -755,7 +755,7 @@ describe('Events V2 API Functions', () => {
 
       expect(mockApi.searchEvents).toHaveBeenCalledWith({
         body: expect.objectContaining({
-          page: { limit: 10000 }
+          page: { limit: 5000 }
         })
       })
     })


### PR DESCRIPTION
## Issue

The Datadog Events API v2 has a hard limit of **5000 events per request**. Our code had:
- Default value: 10000 ❌
- Zod validation max: 10000 ❌

This caused **all** `top` action calls to fail with: `"Limit can't be more than 5000"`

## Verification

Tested via direct API curl:
```bash
# limit 5001
curl -X POST "https://api.datadoghq.com/api/v2/events/search" \
  -H "DD-API-KEY: ***" -H "DD-APPLICATION-KEY: ***" \
  -d '{"filter": {"from": "now-1h", "to": "now"}, "page": {"limit": 5001}}'
# Result: ❌ "invalid_argument(Limit can't be more than 5000)"

# limit 5000
curl -X POST "https://api.datadoghq.com/api/v2/events/search" \
  -H "DD-API-KEY: ***" -H "DD-APPLICATION-KEY: ***" \
  -d '{"filter": {"from": "now-1h", "to": "now"}, "page": {"limit": 5000}}'
# Result: ✅ SUCCESS
```

## Changes

**src/tools/events.ts**:
- Line 71: `.max(5000)` instead of `.max(10000)`
- Line 74: Updated description: `"(default: 5000, max: 5000)"`
- Line 749: Updated comment: `"default 5k, max 5k per Datadog API"`
- Line 760: `params.maxEvents ?? 5000` instead of `10000`

**tests/tools/events-async.test.ts**:
- Line 749: Test name: `"should use default maxEvents of 5000"`
- Line 758: Expected value: `{ limit: 5000 }`

## Testing

✅ All 925 tests passing
✅ Direct API verification confirmed 5000 limit
✅ No breaking changes (parameter still optional, just different default/max)

## Impact

- **Before**: Every `top` action call failed
- **After**: Works correctly with Datadog's actual API limit