### PR TITLE
feat(dashboards): improve dashboard tool based on user feedback

### DIFF
--- a/tests/tools/dashboards-async.test.ts
+++ b/tests/tools/dashboards-async.test.ts
@@ -218,7 +218,7 @@ describe('Dashboards Async Functions', () => {
         title: 'Full Dashboard',
         description: 'Comprehensive dashboard',
         url: '/dashboard/full-123',
-        layout_type: 'ordered' as const,
+        layoutType: 'ordered' as const,
         widgets: [
           {
             id: 1,
@@ -228,15 +228,16 @@ describe('Dashboards Async Functions', () => {
             }
           }
         ],
-        template_variables: [
+        templateVariables: [
           {
             name: 'env',
             prefix: 'env',
-            available_values: ['prod', 'staging'],
+            availableValues: ['prod', 'staging'],
             default: 'prod'
           }
         ],
-        notify_list: ['user@example.com']
+        notifyList: ['user@example.com'],
+        tags: ['team:devops']
       }
 
       const mockApi = {
@@ -247,7 +248,10 @@ describe('Dashboards Async Functions', () => {
 
       expect(result.dashboard.id).toBe('full-123')
       expect(result.dashboard.title).toBe('Full Dashboard')
-      expect(result.dashboard.widgets).toBe(1) // Count of widgets, not the array
+      expect(result.dashboard.widgets).toHaveLength(1) // Full widget array returned
+      expect(result.dashboard.templateVariables).toHaveLength(1) // Template variables included
+      expect(result.dashboard.notifyList).toEqual(['user@example.com']) // Notify list included
+      expect(result.dashboard.tags).toEqual(['team:devops']) // Tags included
     })
 
     it('should handle dashboard with minimal fields', async () => {

--- a/tests/tools/dashboards.test.ts
+++ b/tests/tools/dashboards.test.ts
@@ -82,7 +82,7 @@ describe('Dashboards Tool', () => {
 
       expect(result.dashboard.id).toBe('abc-123')
       expect(result.dashboard.title).toBe('Production Overview')
-      expect(result.dashboard.widgets).toBe(2)
+      expect(result.dashboard.widgets).toHaveLength(2) // Now returns full widget array
     })
 
     it('should handle 404 not found error', async () => {


### PR DESCRIPTION
## Summary

Improvements to the dashboard tool based on real-world usage feedback:

- **Full widget definitions in get**: The `get` action now returns the complete widgets array instead of just a count, enabling users to learn from existing dashboard patterns and clone dashboards
- **Additional metadata**: `get` now includes `templateVariables`, `tags`, `notifyList`, and `reflowType`
- **New validate action**: Test dashboard configurations without hitting the Datadog API - helps debug widget definitions faster
- **Relaxed tag validation**: Tags now accept any `key:value` format (e.g., `team:ops`, `env:prod`, `service:api`) instead of only `team:` prefix
- **Improved tool description**: Documents supported widget formats (simple `q` format and advanced `queries`/`formulas` format)

## Issues Addressed

1. **Widget Schema Validation**: The tool description now documents both simple and advanced widget formats
2. **Get returns summary only**: Fixed - now returns full widget definitions
3. **Tags restriction too strict**: Fixed - now accepts any key:value format
4. **Validate action**: New feature to test configs without API calls

## Test plan

- [x] All existing tests pass (933 tests)
- [x] Added 8 new tests for tag validation and validate action (941 total)
- [x] Build succeeds
- [x] TypeScript types check