### PR TITLE
fix(slos): use search API for list action to return SLI status data

### DIFF
--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -581,6 +581,72 @@ export const slos = {
       }
     ]
   },
+  search: {
+    data: {
+      attributes: {
+        slos: [
+          {
+            data: {
+              id: 'slo-001',
+              type: 'slo',
+              attributes: {
+                name: 'API Availability',
+                description: '99.9% availability for production API',
+                slo_type: 'metric',
+                all_tags: ['service:api', 'env:production'],
+                thresholds: [{ target: 99.9, warning: 99.95, timeframe: '30d' }],
+                status: {
+                  sli: 99.95,
+                  error_budget_remaining: 75.5,
+                  state: 'ok'
+                },
+                overall_status: [
+                  {
+                    status: 99.95,
+                    error_budget_remaining: 75.5,
+                    state: 'ok',
+                    target: 99.9,
+                    timeframe: '30d'
+                  }
+                ],
+                created_at: 1704067200,
+                modified_at: 1705276800
+              }
+            }
+          },
+          {
+            data: {
+              id: 'slo-002',
+              type: 'slo',
+              attributes: {
+                name: 'Payment Processing Latency',
+                description: 'P99 latency under 500ms',
+                slo_type: 'monitor',
+                all_tags: ['service:payments', 'env:production'],
+                thresholds: [{ target: 99.5, timeframe: '7d' }],
+                status: {
+                  sli: 98.2,
+                  error_budget_remaining: -26.0,
+                  state: 'breached'
+                },
+                overall_status: [
+                  {
+                    status: 98.2,
+                    error_budget_remaining: -26.0,
+                    state: 'breached',
+                    target: 99.5,
+                    timeframe: '7d'
+                  }
+                ],
+                created_at: 1704153600,
+                modified_at: 1705363200
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
   single: {
     data: {
       id: 'slo-001',

--- a/tests/helpers/msw.ts
+++ b/tests/helpers/msw.ts
@@ -76,6 +76,7 @@ export const endpoints = {
 
   // P2 Tools - SLOs
   listSlos: `${DD_API_V1}/slo`,
+  searchSlos: `${DD_API_V1}/slo/search`,
   getSlo: (id: string) => `${DD_API_V1}/slo/${id}`,
   createSlo: `${DD_API_V1}/slo`,
   updateSlo: (id: string) => `${DD_API_V1}/slo/${id}`,


### PR DESCRIPTION
## Summary

- Switch SLO `list` action from `listSLOs` to `searchSLO` API endpoint, which returns populated status data (SLI value, error budget remaining, state)
- Add `overallStatus` array to response with per-timeframe breakdown (SLI, error budget, state, target, timeframe)
- Fall back to `listSLOs` when filtering by specific IDs (searchSLO doesn't support ID filtering)

### Before
```json
{
  "status": { "sli": null, "errorBudgetRemaining": null, "state": "unknown" }
}
```

### After
```json
{
  "status": { "sli": 99.695, "errorBudgetRemaining": -203, "state": "breached" },
  "overallStatus": [
    { "sli": 99.695, "errorBudgetRemaining": -203, "state": "breached", "target": 99.9, "timeframe": "7d" }
  ]
}
```

Closes #40

## Test plan

- [x] All 1001 existing tests pass
- [x] New tests for `formatSearchSlo` with status data extraction
- [x] New tests for overall status per-timeframe parsing
- [x] New test for IDs fallback to `listSLOs`
- [x] Typecheck, lint, build all pass
- [ ] Manual verification: rebuild MCP server and run `slos({ action: "list" })`