### PR TITLE
fix: per-session McpServer and bundle deps for npx

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,15 @@
 import { loadConfig } from './config/index.js'
-import { createServer } from './server.js'
+import { createServer, createServerFactory } from './server.js'
 import { connectStdio, connectHttp } from './transport/index.js'
 
 try {
   const config = loadConfig()
-  const server = createServer(config)
 
   if (config.server.transport === 'http') {
-    await connectHttp(server, config.server)
+    const factory = createServerFactory(config)
+    await connectHttp(factory, config.server)
   } else {
+    const server = createServer(config)
     await connectStdio(server)
   }
 } catch (error) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,6 +3,8 @@ import { createDatadogClients } from './config/datadog.js'
 import { registerAllTools } from './tools/index.js'
 import type { Config } from './config/index.js'
 
+export type ServerFactory = () => McpServer
+
 export function createServer(config: Config): McpServer {
   const server = new McpServer({
     name: config.server.name,
@@ -21,4 +23,33 @@ export function createServer(config: Config): McpServer {
   )
 
   return server
+}
+
+/**
+ * Creates a factory that produces a new McpServer per call.
+ * Datadog API clients are created once and shared across instances.
+ *
+ * Required for HTTP transport: Protocol.connect() supports a single
+ * transport, so concurrent sessions each need their own McpServer.
+ */
+export function createServerFactory(config: Config): ServerFactory {
+  const clients = createDatadogClients(config.datadog)
+
+  return () => {
+    const server = new McpServer({
+      name: config.server.name,
+      version: config.server.version
+    })
+
+    registerAllTools(
+      server,
+      clients,
+      config.limits,
+      config.features,
+      config.datadog.site,
+      config.datadog
+    )
+
+    return server
+  }
 }

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -57,8 +57,15 @@ export function createExpressApp(
         }
       }
 
-      const server = createServer()
-      await server.connect(transport)
+      try {
+        const server = createServer()
+        await server.connect(transport)
+      } catch (error) {
+        if (transport.sessionId) {
+          delete transports[transport.sessionId]
+        }
+        throw error
+      }
     } else {
       res.status(400).json({
         jsonrpc: '2.0',

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -1,25 +1,31 @@
 /**
  * HTTP/StreamableHTTP transport for MCP server
  * Allows running the server over HTTP with configurable port
+ *
+ * Creates a new McpServer per session to avoid the single-transport
+ * limitation of Protocol.connect() — concurrent sessions each get
+ * their own server instance with isolated transport routing.
  */
 import express, { Request, Response } from 'express'
 import { randomUUID } from 'node:crypto'
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js'
+import type { ServerFactory } from '../server.js'
 import type { ServerConfig } from '../config/schema.js'
-
-// Store active transports by session ID
-const transports: Record<string, StreamableHTTPServerTransport> = {}
 
 /**
  * Creates and configures an Express app for MCP server
  * Exported for testing purposes
  */
-export function createExpressApp(server: McpServer, config: ServerConfig): express.Application {
+export function createExpressApp(
+  createServer: ServerFactory,
+  config: ServerConfig
+): express.Application {
   const app = express()
   app.disable('x-powered-by')
   app.use(express.json())
+
+  const transports: Record<string, StreamableHTTPServerTransport> = {}
 
   // Health check endpoint
   app.get('/health', (_req: Request, res: Response) => {
@@ -35,7 +41,7 @@ export function createExpressApp(server: McpServer, config: ServerConfig): expre
       // Reuse existing session
       transport = transports[sessionId]
     } else if (!sessionId && isInitializeRequest(req.body)) {
-      // New session initialization
+      // New session — create dedicated server instance
       transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
         onsessioninitialized: (id) => {
@@ -51,6 +57,7 @@ export function createExpressApp(server: McpServer, config: ServerConfig): expre
         }
       }
 
+      const server = createServer()
       await server.connect(transport)
     } else {
       res.status(400).json({
@@ -87,8 +94,11 @@ export function createExpressApp(server: McpServer, config: ServerConfig): expre
   return app
 }
 
-export async function connectHttp(server: McpServer, config: ServerConfig): Promise<void> {
-  const app = createExpressApp(server, config)
+export async function connectHttp(
+  createServer: ServerFactory,
+  config: ServerConfig
+): Promise<void> {
+  const app = createExpressApp(createServer, config)
 
   // Start server
   app.listen(config.port, config.host, () => {

--- a/tests/transport/http.test.ts
+++ b/tests/transport/http.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import request from 'supertest'
 import { createExpressApp } from '../../src/transport/http.js'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { ServerFactory } from '../../src/server.js'
 import type { ServerConfig } from '../../src/config/schema.js'
 
 // Type for mock transport instance
@@ -51,12 +52,15 @@ vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
 
 describe('HTTP Transport', () => {
   let mockServer: McpServer
+  let createMockServer: ServerFactory
   let config: ServerConfig
 
   beforeEach(() => {
     mockServer = {
       connect: vi.fn().mockResolvedValue(undefined)
     } as unknown as McpServer
+
+    createMockServer = vi.fn().mockReturnValue(mockServer)
 
     config = {
       name: 'test-server',
@@ -74,7 +78,7 @@ describe('HTTP Transport', () => {
 
   describe('Health Check', () => {
     it('should respond to health check endpoint', async () => {
-      const app = createExpressApp(mockServer, config)
+      const app = createExpressApp(createMockServer, config)
 
       const response = await request(app).get('/health')
 
@@ -87,7 +91,7 @@ describe('HTTP Transport', () => {
     })
 
     it('should not include x-powered-by header', async () => {
-      const app = createExpressApp(mockServer, config)
+      const app = createExpressApp(createMockServer, config)
 
       const response = await request(app).get('/health')
 
@@ -97,7 +101,7 @@ describe('HTTP Transport', () => {
 
   describe('Session Management', () => {
     it('should reject POST without session ID and non-initialize request', async () => {
-      const app = createExpressApp(mockServer, config)
+      const app = createExpressApp(createMockServer, config)
 
       const response = await request(app)
         .post('/mcp')
@@ -112,7 +116,7 @@ describe('HTTP Transport', () => {
     })
 
     it('should handle GET with invalid session', async () => {
-      const app = createExpressApp(mockServer, config)
+      const app = createExpressApp(createMockServer, config)
 
       const response = await request(app).get('/mcp').set('mcp-session-id', 'nonexistent-session')
 
@@ -121,7 +125,7 @@ describe('HTTP Transport', () => {
     })
 
     it('should handle DELETE with invalid session', async () => {
-      const app = createExpressApp(mockServer, config)
+      const app = createExpressApp(createMockServer, config)
 
       const response = await request(app)
         .delete('/mcp')
@@ -133,10 +137,10 @@ describe('HTTP Transport', () => {
   })
 
   describe('Initialization', () => {
-    it('should accept initialize request without session ID', async () => {
-      const app = createExpressApp(mockServer, config)
+    it('should create a new server instance per session', async () => {
+      const app = createExpressApp(createMockServer, config)
 
-      const response = await request(app)
+      await request(app)
         .post('/mcp')
         .send({
           jsonrpc: '2.0',
@@ -151,14 +155,56 @@ describe('HTTP Transport', () => {
       // Wait for session initialization
       await new Promise((resolve) => setTimeout(resolve, 10))
 
-      expect(response.status).toBe(200)
+      expect(createMockServer).toHaveBeenCalledTimes(1)
       expect(mockServer.connect).toHaveBeenCalled()
+    })
+
+    it('should create separate server instances for concurrent sessions', async () => {
+      const servers = [
+        { connect: vi.fn().mockResolvedValue(undefined) },
+        { connect: vi.fn().mockResolvedValue(undefined) }
+      ] as unknown as McpServer[]
+
+      let callCount = 0
+      const factory = vi.fn(() => servers[callCount++]) as unknown as ServerFactory
+
+      const app = createExpressApp(factory, config)
+
+      // Two concurrent initialize requests
+      await Promise.all([
+        request(app)
+          .post('/mcp')
+          .send({
+            jsonrpc: '2.0',
+            method: 'initialize',
+            params: {
+              protocolVersion: '2024-11-05',
+              clientInfo: { name: 'client-1', version: '1.0.0' }
+            },
+            id: 1
+          }),
+        request(app)
+          .post('/mcp')
+          .send({
+            jsonrpc: '2.0',
+            method: 'initialize',
+            params: {
+              protocolVersion: '2024-11-05',
+              clientInfo: { name: 'client-2', version: '1.0.0' }
+            },
+            id: 2
+          })
+      ])
+
+      expect(factory).toHaveBeenCalledTimes(2)
+      expect(servers[0].connect).toHaveBeenCalledTimes(1)
+      expect(servers[1].connect).toHaveBeenCalledTimes(1)
     })
   })
 
   describe('Express Middleware', () => {
     it('should parse JSON body', async () => {
-      const app = createExpressApp(mockServer, config)
+      const app = createExpressApp(createMockServer, config)
 
       // Test that JSON parsing works by sending an initialize request
       const response = await request(app)
@@ -175,7 +221,7 @@ describe('HTTP Transport', () => {
     })
 
     it('should handle malformed JSON', async () => {
-      const app = createExpressApp(mockServer, config)
+      const app = createExpressApp(createMockServer, config)
 
       const response = await request(app)
         .post('/mcp')

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,7 +7,12 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   target: 'node18',
+  noExternal: [/.*/],
   banner: {
-    js: '#!/usr/bin/env node'
+    js: [
+      '#!/usr/bin/env node',
+      'import { createRequire as __createRequire } from "module";',
+      'const require = __createRequire(import.meta.url);'
+    ].join('\n')
   }
 })


### PR DESCRIPTION
## Summary

- **Per-session McpServer for HTTP transport**: Each new StreamableHTTP session now gets its own `McpServer` instance via `createServerFactory()`, fixing tool handler conflicts when multiple clients connect in parallel.
- **Bundle all dependencies for reliable `npx` execution**: `npx -y datadog-mcp` was failing on Node.js v22 with `Cannot find package 'zod'` due to ESM resolution issues in the npx temp cache. All runtime deps are now bundled into `dist/index.js` with a `createRequire` shim for CJS compatibility.

## Test plan

- [x] All 1008 tests pass (63 test files)
- [x] Bundled `dist/index.js` starts correctly (validated no import errors)
- [x] Pre-commit hooks (prettier + eslint) pass
- [ ] Verify `npx -y datadog-mcp` works on Node.js v22