### PR TITLE
fix(build): bundle all dependencies for reliable npx execution

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,7 +7,12 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   target: 'node18',
+  noExternal: [/.*/],
   banner: {
-    js: '#!/usr/bin/env node'
+    js: [
+      '#!/usr/bin/env node',
+      'import { createRequire as __createRequire } from "module";',
+      'const require = __createRequire(import.meta.url);'
+    ].join('\n')
   }
 })


### PR DESCRIPTION
## Summary

- `npx -y datadog-mcp` fails on Node.js v22 with `Cannot find package 'zod'` due to ESM resolution issues in the npx temporary cache directory
- Bundle all runtime dependencies into `dist/index.js` using tsup's `noExternal` option
- Add `createRequire` shim so bundled CJS transitive deps (whatwg-url, ajv) work in the ESM output

## Test plan

- [x] All 1008 tests pass (63 test files)
- [x] Bundled `dist/index.js` starts correctly (no import errors)
- [x] Pre-commit hooks (prettier + eslint) pass
- [ ] Verify `npx -y datadog-mcp` works on Node.js v22