### PR TITLE
feat(monitors): expose options, multi, priority, restricted_roles on get/update

### DIFF
--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -90,6 +90,30 @@ export function formatMonitor(m: v1.Monitor, site: string = 'datadoghq.com'): Mo
   }
 }
 
+export interface MonitorDetail extends MonitorSummary {
+  options?: v1.MonitorOptions
+  multi?: boolean
+  priority?: number | null
+  restrictedRoles?: string[]
+}
+
+export function formatMonitorDetail(m: v1.Monitor, site: string = 'datadoghq.com'): MonitorDetail {
+  const detail: MonitorDetail = { ...formatMonitor(m, site) }
+  if (m.options != null) {
+    detail.options = m.options
+  }
+  if (m.multi != null) {
+    detail.multi = m.multi
+  }
+  if (m.priority != null) {
+    detail.priority = m.priority
+  }
+  if (m.restrictedRoles != null) {
+    detail.restrictedRoles = m.restrictedRoles
+  }
+  return detail
+}
+
 export async function listMonitors(
   api: v1.MonitorsApi,
   params: { name?: string; tags?: string[]; groupStates?: string[]; limit?: number },
@@ -132,7 +156,7 @@ export async function getMonitor(api: v1.MonitorsApi, id: string, site: string) 
 
   const monitor = await api.getMonitor({ monitorId })
   return {
-    monitor: formatMonitor(monitor, site),
+    monitor: formatMonitorDetail(monitor, site),
     datadog_url: buildMonitorUrl(monitorId, site)
   }
 }
@@ -243,7 +267,7 @@ export async function createMonitor(
   const monitor = await api.createMonitor({ body })
   return {
     success: true,
-    monitor: formatMonitor(monitor, site)
+    monitor: formatMonitorDetail(monitor, site)
   }
 }
 
@@ -258,7 +282,7 @@ export async function updateMonitor(
   const monitor = await api.updateMonitor({ monitorId, body })
   return {
     success: true,
-    monitor: formatMonitor(monitor, site)
+    monitor: formatMonitorDetail(monitor, site)
   }
 }
 
@@ -492,6 +516,7 @@ export function registerMonitorsTool(
     'monitors',
     `Manage Datadog monitors. Actions: list, get, search, create, update, delete, mute, unmute, top.
 Filters: name, tags, groupStates (alert/warn/ok/no data).
+get/create/update return the full options object (notify_no_data, renotify_interval, thresholds, etc.) so callers can safely read-then-patch.
 
 top: Ranked monitors by alert frequency with real monitor names and context breakdown.
   - Returns: {rank, monitor_id, name (with {{template.vars}}), message (template), total_count, by_context}

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -93,7 +93,7 @@ export function formatMonitor(m: v1.Monitor, site: string = 'datadoghq.com'): Mo
 export interface MonitorDetail extends MonitorSummary {
   options?: v1.MonitorOptions
   multi?: boolean
-  priority?: number | null
+  priority?: number
   restrictedRoles?: string[]
 }
 

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -38,9 +38,17 @@ export const monitors = {
     overall_state: 'Alert',
     created: '2024-01-15T10:00:00.000Z',
     modified: '2024-01-20T15:30:00.000Z',
+    multi: true,
+    priority: 3,
+    restricted_roles: ['role-uuid-1'],
     options: {
       thresholds: { critical: 90, warning: 80 },
-      notify_no_data: true
+      notify_no_data: true,
+      no_data_timeframe: 60,
+      renotify_interval: 30,
+      timeout_h: 24,
+      include_tags: true,
+      escalation_message: 'Escalating to oncall'
     }
   },
   searchResults: {

--- a/tests/tools/monitors.test.ts
+++ b/tests/tools/monitors.test.ts
@@ -173,6 +173,38 @@ describe('Monitors Tool', () => {
     it('should handle invalid monitor ID', async () => {
       await expect(getMonitor(api, 'invalid', defaultSite)).rejects.toThrow('Invalid monitor ID')
     })
+
+    it('exposes options, multi, priority, and restrictedRoles on get response', async () => {
+      server.use(
+        http.get(endpoints.getMonitor(12345), () => {
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      const result = await getMonitor(api, '12345', defaultSite)
+
+      expect(result.monitor.options).toBeDefined()
+      expect(typeof result.monitor.options).toBe('object')
+      expect(result.monitor.multi).toBe(true)
+      expect(result.monitor.priority).toBe(3)
+      expect(Array.isArray(result.monitor.restrictedRoles)).toBe(true)
+      expect(result.monitor.restrictedRoles?.length).toBeGreaterThan(0)
+    })
+
+    it('preserves nested option fields (renotifyInterval, notifyNoData, includeTags, escalationMessage)', async () => {
+      server.use(
+        http.get(endpoints.getMonitor(12345), () => {
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      const result = await getMonitor(api, '12345', defaultSite)
+
+      expect(result.monitor.options?.renotifyInterval).toBe(30)
+      expect(result.monitor.options?.notifyNoData).toBe(true)
+      expect(result.monitor.options?.includeTags).toBe(true)
+      expect(result.monitor.options?.escalationMessage).toBe('Escalating to oncall')
+    })
   })
 
   describe('searchMonitors', () => {
@@ -271,6 +303,30 @@ describe('Monitors Tool', () => {
       expect(result.success).toBe(true)
       expect(result.monitor.name).toBe('Updated Monitor Name')
       expect(result.monitor.url).toBe('https://app.datadoghq.com/monitors/12345')
+    })
+
+    it('returns the full options object after update', async () => {
+      server.use(
+        http.put(endpoints.getMonitor(12345), async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>
+          return jsonResponse({
+            ...fixtures.single,
+            ...body
+          })
+        })
+      )
+
+      const result = await updateMonitor(api, '12345', {
+        name: 'Updated Monitor Name',
+        type: 'metric alert',
+        query: 'test'
+      })
+
+      expect(result.monitor.options).toBeDefined()
+      expect(result.monitor.options?.renotifyInterval).toBe(30)
+      expect(result.monitor.options?.notifyNoData).toBe(true)
+      expect(result.monitor.options?.includeTags).toBe(true)
+      expect(result.monitor.options?.escalationMessage).toBe('Escalating to oncall')
     })
   })
 


### PR DESCRIPTION
## Summary

Closes #51.

`formatMonitor()` was projecting `v1.Monitor` down to ~10 fields and dropping `options`, `multi`, `priority`, `restrictedRoles`. As a result, `action: get` returned a partial view and `action: update` was unsafe — callers couldn't read current option values before patching, and Datadog could reset omitted options to defaults.

This PR adds a `MonitorDetail` interface and a `formatMonitorDetail()` helper used by `get` / `create` / `update`. `list` and `search` responses keep the leaner `MonitorSummary` shape so bulk responses stay token-efficient.

### What's exposed now (on get/create/update)

- `options` — full `v1.MonitorOptions` (notify_no_data, renotify_interval, thresholds, escalation_message, timeout_h, etc.)
- `multi` — boolean
- `priority` — number | null
- `restrictedRoles` — string[]

### Out of scope

- `overall_state_modified` from the issue body — the field is **not exposed by the Datadog SDK's `v1.Monitor` type**, so it cannot be returned without a custom HTTP client. Tracked as a follow-up if the SDK adds it.
- Bulk operations / dry-run / other items in #49.

## Files changed

| File | Change |
|---|---|
| `src/tools/monitors.ts` | +30 lines — new `MonitorDetail` interface, `formatMonitorDetail()`, 3 callsite switches, 1 tool-description line |
| `tests/helpers/fixtures.ts` | `monitors.single` extended with `multi`, `priority`, `restricted_roles`, and a richer `options` block |
| `tests/tools/monitors.test.ts` | +3 new test cases (2 in `getMonitor`, 1 in `updateMonitor`) |

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm run build` — succeeds
- [x] `npm test -- --run` — 1011/1011 passing (was 1008, +3 new for the new fields)
- [x] Type coverage — 99.82% (above 90% threshold)
- [x] `listMonitors` / `searchMonitors` / `topMonitors` shape unchanged (no regressions)
- [x] New tests assert positive presence of `options`, `multi`, `priority`, `restrictedRoles` and 4 nested option fields (`renotifyInterval`, `notifyNoData`, `includeTags`, `escalationMessage`)