### PR TITLE
feat(monitors): typed schema validation for config.options (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ When running with `--transport=http`:
 | `monitors` | list | Alerting | List monitors with optional filters | `monitors_read` |
 | `monitors` | get | Alerting | Get monitor by ID | `monitors_read` |
 | `monitors` | search | Alerting | Search monitors by query | `monitors_read` |
-| `monitors` | create | Alerting | Create a new monitor | `monitors_write` |
-| `monitors` | update | Alerting | Update an existing monitor | `monitors_write` |
+| `monitors` | create | Alerting | Create a new monitor; `config` is validated against a typed schema covering documented options (notifyNoData, renotifyInterval, thresholds, …) — unknown keys surface in `warnings` | `monitors_write` |
+| `monitors` | update | Alerting | Update an existing monitor; same validated schema as `create`; partial configs accepted; validation errors short-circuit before any HTTP call as `EINVALID_MONITOR_CONFIG:` | `monitors_write` |
 | `monitors` | delete | Alerting | Delete a monitor | `monitors_write` |
 | `monitors` | mute | Alerting | Mute a monitor | `monitors_write` |
 | `monitors` | unmute | Alerting | Unmute a monitor | `monitors_write` |

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -130,6 +130,29 @@ export const MonitorOptionsSchema = z
   })
   .passthrough()
 
+// Validated schema for top-level `config` keys (see design.md Data model).
+// Eight documented top-level keys are enumerated; `options` composes
+// `MonitorOptionsSchema`. `priority` is constrained to integers 1–5 per
+// Datadog's documented priority range (Requirement 2.4); `.nullable()`
+// allows callers to clear it on update. `.passthrough()` preserves unknown
+// top-level keys; `collectUnknownKeyWarnings` (Task 5) emits warnings for
+// those keys.
+export const MonitorConfigSchema = z
+  .object({
+    name: z.string().optional(),
+    type: z.string().optional(),
+    query: z.string().optional(),
+    message: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+    priority: z.number().int().min(1).max(5).nullable().optional(),
+    restrictedRoles: z.array(z.string()).nullable().optional(),
+    multi: z.boolean().optional(),
+    options: MonitorOptionsSchema.optional()
+  })
+  .passthrough()
+
+export type MonitorConfigInput = z.infer<typeof MonitorConfigSchema>
+
 interface MonitorSummary {
   id: number
   name: string

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -61,6 +61,38 @@ const InputSchema = {
     .describe('Maximum events to fetch for top action (default: 5000, max: 5000)')
 }
 
+// Nested schemas for MonitorOptionsSchema (see design.md Data model).
+// Each uses .passthrough() so unknown sub-keys are forwarded to Datadog unchanged.
+// Exported so they can be composed by MonitorOptionsSchema (Task 2) and asserted
+// by unit tests (Task 9) without changing module-local visibility later.
+// Thresholds — values are all documented as numbers in Datadog Monitor API
+export const MonitorThresholdsSchema = z
+  .object({
+    critical: z.number().optional(),
+    warning: z.number().optional(),
+    ok: z.number().optional(),
+    criticalRecovery: z.number().optional(),
+    warningRecovery: z.number().optional(),
+    unknown: z.number().optional()
+  })
+  .passthrough()
+
+// Threshold windows for anomaly / forecast monitors
+export const MonitorThresholdWindowsSchema = z
+  .object({
+    triggerWindow: z.string().optional(),
+    recoveryWindow: z.string().optional()
+  })
+  .passthrough()
+
+// Scheduling options (e.g., evaluation_window for SLO-driven monitors)
+export const SchedulingOptionsSchema = z
+  .object({
+    evaluationWindow: z.record(z.unknown()).optional(),
+    customSchedule: z.record(z.unknown()).optional()
+  })
+  .passthrough()
+
 interface MonitorSummary {
   id: number
   name: string

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -153,6 +153,25 @@ export const MonitorConfigSchema = z
 
 export type MonitorConfigInput = z.infer<typeof MonitorConfigSchema>
 
+// Known-key sets derived from the schema shapes — single source of truth
+// (see design.md "Risks and trade-offs" → "Deriving KNOWN_*_KEYS from
+// Object.keys(schema.shape) rather than hand-maintaining a parallel list").
+// DO NOT refactor these to hand-maintained literals: drift between the
+// schemas and the warning logic (Task 5) would re-introduce the silent
+// pass-through bug this spec is fixing. Used by `collectUnknownKeyWarnings`
+// to diff caller input against the validated key set.
+// `options` is excluded from KNOWN_TOP_LEVEL_KEYS because it is a known
+// nested holder (validated via MonitorOptionsSchema) — flagging it as an
+// unknown top-level key would emit a spurious warning whenever a caller
+// supplies any nested options.
+export const KNOWN_TOP_LEVEL_KEYS: ReadonlySet<string> = new Set(
+  Object.keys(MonitorConfigSchema.shape).filter((key) => key !== 'options')
+)
+
+export const KNOWN_OPTIONS_KEYS: ReadonlySet<string> = new Set(
+  Object.keys(MonitorOptionsSchema.shape)
+)
+
 interface MonitorSummary {
   id: number
   name: string

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -217,6 +217,28 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
+/**
+ * Summarize the FIRST issue from a `ZodError` into a single-line string for
+ * the `EINVALID_MONITOR_CONFIG:` error message (design.md "Error handling" →
+ * row 1). Includes the dotted key path and the expected type so callers can
+ * locate and fix the wrong-type value without parsing the full ZodError.
+ */
+function summarizeZodIssue(error: z.ZodError): string {
+  const issue = error.issues[0]
+  if (!issue) {
+    return 'validation failed'
+  }
+  const path = issue.path.length > 0 ? issue.path.join('.') : '<root>'
+  // `z.ZodInvalidTypeIssue` carries an `expected` field; other issue codes
+  // (out-of-range, etc.) do not. Fall back to the issue `message` so callers
+  // still see a useful hint (e.g., "Number must be less than or equal to 5").
+  const expected =
+    issue.code === 'invalid_type' && 'expected' in issue
+      ? `expected ${String(issue.expected)}`
+      : issue.message
+  return `${path}: ${expected}`
+}
+
 interface MonitorSummary {
   id: number
   name: string
@@ -419,12 +441,33 @@ export async function createMonitor(
   config: Record<string, unknown>,
   site: string = 'datadoghq.com'
 ) {
-  const body = normalizeMonitorConfig(config) as unknown as v1.Monitor
+  const normalized = normalizeMonitorConfig(config)
+
+  // Validate the normalized (camelCase) config against the typed schema before
+  // any HTTP call (design.md "Sequence / control flow" steps 4–7). Wrong-type
+  // values surface as `EINVALID_MONITOR_CONFIG:` errors; `.passthrough()`
+  // preserves unknown keys so they still reach Datadog.
+  try {
+    MonitorConfigSchema.parse(normalized)
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(`EINVALID_MONITOR_CONFIG: ${summarizeZodIssue(error)}`)
+    }
+    throw error
+  }
+
+  const warnings = collectUnknownKeyWarnings(normalized)
+
+  const body = normalized as unknown as v1.Monitor
   const monitor = await api.createMonitor({ body })
-  return {
+  const result: { success: true; monitor: MonitorDetail; warnings?: string[] } = {
     success: true,
     monitor: formatMonitorDetail(monitor, site)
   }
+  if (warnings.length > 0) {
+    result.warnings = warnings
+  }
+  return result
 }
 
 export async function updateMonitor(

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -738,7 +738,21 @@ export function registerMonitorsTool(
     'monitors',
     `Manage Datadog monitors. Actions: list, get, search, create, update, delete, mute, unmute, top.
 Filters: name, tags, groupStates (alert/warn/ok/no data).
-get/create/update return the full options object (notify_no_data, renotify_interval, thresholds, etc.) so callers can safely read-then-patch.
+get/create/update return the full options object so callers can safely read-then-patch.
+
+create/update accept a config object validated against a typed schema covering the documented Datadog Monitor fields:
+  - Top-level: name, type, query, message, tags, priority (1-5, nullable), restrictedRoles, multi, options.
+  - options.* validated keys grouped by category:
+    - notification:    notifyNoData, noDataTimeframe, notifyAudit, notificationPresetName.
+    - evaluation/delay: newHostDelay, newGroupDelay, evaluationDelay, requireFullWindow, onMissingData.
+    - renotification:  renotifyInterval (nullable), renotifyOccurrences, renotifyStatuses, escalationMessage.
+    - lifecycle:       timeoutH (nullable), includeTags, locked, silenced (record of timestamps/null), groupRetentionDuration.
+    - thresholds:      thresholds (critical/warning/ok/criticalRecovery/warningRecovery/unknown), thresholdWindows.
+    - scheduling:      schedulingOptions.
+Unknown keys (top-level or under options) are forwarded to Datadog as-is and surfaced via an optional warnings array on the response, so the schema does not lag the API.
+snake_case aliases are accepted on input and normalized to camelCase before validation.
+Validation errors short-circuit before any HTTP call and surface as 'EINVALID_MONITOR_CONFIG: <path>: <expected>'.
+Reference: https://docs.datadoghq.com/api/latest/monitors/
 
 top: Ranked monitors by alert frequency with real monitor names and context breakdown.
   - Returns: {rank, monitor_id, name (with {{template.vars}}), message (template), total_count, by_context}

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -477,12 +477,35 @@ export async function updateMonitor(
   site: string = 'datadoghq.com'
 ) {
   const monitorId = Number.parseInt(id, 10)
-  const body = normalizeMonitorConfig(config, true) as unknown as v1.MonitorUpdateRequest
+  const normalized = normalizeMonitorConfig(config, true)
+
+  // Validate the normalized (camelCase) config against the typed schema before
+  // any HTTP call (design.md "Sequence / control flow" steps 4–7). Partial
+  // configs are accepted because every key on `MonitorConfigSchema` is
+  // `.optional()`; only the supplied keys are forwarded to Datadog. Wrong-type
+  // values surface as `EINVALID_MONITOR_CONFIG:` errors; `.passthrough()`
+  // preserves unknown keys so they still reach Datadog.
+  try {
+    MonitorConfigSchema.parse(normalized)
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw new Error(`EINVALID_MONITOR_CONFIG: ${summarizeZodIssue(error)}`)
+    }
+    throw error
+  }
+
+  const warnings = collectUnknownKeyWarnings(normalized)
+
+  const body = normalized as unknown as v1.MonitorUpdateRequest
   const monitor = await api.updateMonitor({ monitorId, body })
-  return {
+  const result: { success: true; monitor: MonitorDetail; warnings?: string[] } = {
     success: true,
     monitor: formatMonitorDetail(monitor, site)
   }
+  if (warnings.length > 0) {
+    result.warnings = warnings
+  }
+  return result
 }
 
 export async function deleteMonitor(api: v1.MonitorsApi, id: string) {

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -172,6 +172,51 @@ export const KNOWN_OPTIONS_KEYS: ReadonlySet<string> = new Set(
   Object.keys(MonitorOptionsSchema.shape)
 )
 
+/**
+ * Collect human-readable warnings for any keys in `config` (or `config.options`)
+ * that the validated schema does not enumerate. Pure function — operates on the
+ * already-normalized (post-`normalizeMonitorConfig`, camelCase) config so that
+ * documented snake_case aliases do NOT appear as unknown.
+ *
+ * Ordering (Requirement 4.4): top-level unknowns first, then options unknowns;
+ * within each group, the caller's insertion order is preserved so that log
+ * diffing is deterministic.
+ *
+ * Robustness: `config.options` being absent, `null`, a non-object, or an array
+ * is tolerated silently — the nested scan is simply skipped. This mirrors the
+ * normalizer's lenient handling and avoids throwing before schema validation
+ * has a chance to surface a better error.
+ *
+ * @param config Normalized monitor config (output of `normalizeMonitorConfig`).
+ * @returns Stable-ordered warnings; empty array when all keys are recognised.
+ */
+export function collectUnknownKeyWarnings(config: Record<string, unknown>): string[] {
+  const warnings: string[] = []
+
+  for (const key of Object.keys(config)) {
+    if (!KNOWN_TOP_LEVEL_KEYS.has(key) && key !== 'options') {
+      warnings.push(`unknown top-level key '${key}' under config forwarded without validation`)
+    }
+  }
+
+  const options = config.options
+  if (isPlainObject(options)) {
+    for (const key of Object.keys(options)) {
+      if (!KNOWN_OPTIONS_KEYS.has(key)) {
+        warnings.push(
+          `unknown option key '${key}' under config.options forwarded without validation`
+        )
+      }
+    }
+  }
+
+  return warnings
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
 interface MonitorSummary {
   id: number
   name: string

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -385,7 +385,10 @@ export function normalizeMonitorConfig(
   if (normalized.options && typeof normalized.options === 'object') {
     const opts = { ...(normalized.options as Record<string, unknown>) }
 
-    // Common snake_case -> camelCase conversions
+    // Common snake_case -> camelCase conversions. Keep this in sync with
+    // `MonitorOptionsSchema` so every documented camelCase key has its
+    // snake_case alias mapped — missing entries surface as spurious
+    // "unknown option key" warnings for callers using snake_case.
     const optionMappings: [string, string][] = [
       ['notify_no_data', 'notifyNoData'],
       ['no_data_timeframe', 'noDataTimeframe'],
@@ -400,6 +403,11 @@ export function normalizeMonitorConfig(
       ['include_tags', 'includeTags'],
       ['require_full_window', 'requireFullWindow'],
       ['escalation_message', 'escalationMessage'],
+      ['notification_preset_name', 'notificationPresetName'],
+      ['on_missing_data', 'onMissingData'],
+      ['group_retention_duration', 'groupRetentionDuration'],
+      ['threshold_windows', 'thresholdWindows'],
+      ['scheduling_options', 'schedulingOptions'],
       ['locked', 'locked'],
       ['silenced', 'silenced']
     ]

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -93,6 +93,43 @@ export const SchedulingOptionsSchema = z
   })
   .passthrough()
 
+// Validated schema for `config.options.*` keys (see design.md Data model).
+// Each documented Datadog Monitor options key is typed; nullable keys
+// (`renotifyInterval`, `timeoutH`, `silenced` values) follow Datadog docs.
+// `.passthrough()` preserves unknown keys so callers can use newly-shipped
+// Datadog options before this schema enumerates them; `collectUnknownKeyWarnings`
+// (Task 5) emits warnings for those keys.
+export const MonitorOptionsSchema = z
+  .object({
+    // Notification
+    notifyNoData: z.boolean().optional(),
+    noDataTimeframe: z.number().optional(),
+    notifyAudit: z.boolean().optional(),
+    notificationPresetName: z.string().optional(),
+    // Evaluation / delay
+    newHostDelay: z.number().optional(),
+    newGroupDelay: z.number().optional(),
+    evaluationDelay: z.number().optional(),
+    requireFullWindow: z.boolean().optional(),
+    onMissingData: z.string().optional(),
+    // Renotification
+    renotifyInterval: z.number().nullable().optional(),
+    renotifyOccurrences: z.number().optional(),
+    renotifyStatuses: z.array(z.string()).optional(),
+    escalationMessage: z.string().optional(),
+    // Lifecycle
+    timeoutH: z.number().nullable().optional(),
+    includeTags: z.boolean().optional(),
+    locked: z.boolean().optional(),
+    silenced: z.record(z.number().nullable()).optional(),
+    groupRetentionDuration: z.string().optional(),
+    // Thresholds & scheduling
+    thresholds: MonitorThresholdsSchema.optional(),
+    thresholdWindows: MonitorThresholdWindowsSchema.optional(),
+    schedulingOptions: SchedulingOptionsSchema.optional()
+  })
+  .passthrough()
+
 interface MonitorSummary {
   id: number
   name: string

--- a/tests/tools/monitors-helpers.test.ts
+++ b/tests/tools/monitors-helpers.test.ts
@@ -3,7 +3,7 @@
  * Focus on normalizeMonitorConfig which is completely untested (lines 146-194)
  */
 import { describe, it, expect } from 'vitest'
-import { normalizeMonitorConfig } from '../../src/tools/monitors.js'
+import { normalizeMonitorConfig, collectUnknownKeyWarnings } from '../../src/tools/monitors.js'
 
 describe('Monitors Helper Functions', () => {
   describe('normalizeMonitorConfig', () => {
@@ -307,6 +307,197 @@ describe('Monitors Helper Functions', () => {
 
       // Other fields preserved
       expect(result.options).toHaveProperty('other_field', 'preserved')
+    })
+  })
+
+  describe('collectUnknownKeyWarnings', () => {
+    it('returns empty array for fully validated input (all known keys)', () => {
+      const config = {
+        name: 'Test',
+        type: 'metric alert',
+        query: 'avg:system.load.1{*} > 2',
+        message: 'Alert!',
+        tags: ['env:prod'],
+        priority: 3,
+        restrictedRoles: ['admin'],
+        multi: true,
+        options: {
+          notifyNoData: true,
+          noDataTimeframe: 60,
+          renotifyInterval: 120,
+          thresholds: { critical: 90 }
+        }
+      }
+
+      expect(collectUnknownKeyWarnings(config)).toEqual([])
+    })
+
+    it('returns empty array for empty config', () => {
+      expect(collectUnknownKeyWarnings({})).toEqual([])
+    })
+
+    it('reports unknown top-level keys with config location', () => {
+      const config = {
+        name: 'Test',
+        fooBar: 'value',
+        bazQux: 42
+      }
+
+      const warnings = collectUnknownKeyWarnings(config)
+
+      expect(warnings).toHaveLength(2)
+      expect(warnings[0]).toContain("'fooBar'")
+      expect(warnings[0]).toContain('config')
+      expect(warnings[0]).not.toContain('config.options')
+      expect(warnings[1]).toContain("'bazQux'")
+      expect(warnings[1]).toContain('config')
+      expect(warnings[1]).not.toContain('config.options')
+    })
+
+    it('reports unknown options keys with config.options location', () => {
+      const config = {
+        name: 'Test',
+        options: {
+          notifyNoData: true,
+          someNewOption: 'value',
+          anotherUnknown: 123
+        }
+      }
+
+      const warnings = collectUnknownKeyWarnings(config)
+
+      expect(warnings).toHaveLength(2)
+      expect(warnings[0]).toContain("'someNewOption'")
+      expect(warnings[0]).toContain('config.options')
+      expect(warnings[1]).toContain("'anotherUnknown'")
+      expect(warnings[1]).toContain('config.options')
+    })
+
+    it('reports both top-level and options unknowns with top-level first', () => {
+      const config = {
+        topLevelUnknown: 'value',
+        name: 'Test',
+        options: {
+          notifyNoData: true,
+          optionsUnknown: 'value'
+        }
+      }
+
+      const warnings = collectUnknownKeyWarnings(config)
+
+      expect(warnings).toHaveLength(2)
+      expect(warnings[0]).toContain("'topLevelUnknown'")
+      expect(warnings[0]).toContain('config')
+      expect(warnings[0]).not.toContain('config.options')
+      expect(warnings[1]).toContain("'optionsUnknown'")
+      expect(warnings[1]).toContain('config.options')
+    })
+
+    it('preserves insertion order of unknown keys within each group', () => {
+      const config = {
+        zebra: 1,
+        name: 'Test',
+        alpha: 2,
+        middle: 3,
+        options: {
+          zulu: 1,
+          notifyNoData: true,
+          alphaOpt: 2,
+          mikeOpt: 3
+        }
+      }
+
+      const warnings = collectUnknownKeyWarnings(config)
+
+      // 3 top-level unknowns (zebra, alpha, middle) + 3 options unknowns
+      // (zulu, alphaOpt, mikeOpt); `name`, `options`, `notifyNoData` are known.
+      expect(warnings).toHaveLength(6)
+      // Top-level unknowns, insertion order
+      expect(warnings[0]).toContain("'zebra'")
+      expect(warnings[1]).toContain("'alpha'")
+      expect(warnings[2]).toContain("'middle'")
+      // Then options unknowns, insertion order
+      expect(warnings[3]).toContain("'zulu'")
+      expect(warnings[4]).toContain("'alphaOpt'")
+      expect(warnings[5]).toContain("'mikeOpt'")
+    })
+
+    it('preserves exact key casing including snake_case (post-normalization residual)', () => {
+      // Snake_case keys that the normalizer did NOT map (because they aren't in
+      // the alias table) appear as unknown. The warning must preserve the
+      // caller's exact spelling so they can grep their source.
+      const config = {
+        name: 'Test',
+        SomeWeirdKey: 'x',
+        options: {
+          notify_no_data_typo: true,
+          ANOTHER_UNUSUAL: 5
+        }
+      }
+
+      const warnings = collectUnknownKeyWarnings(config)
+
+      expect(warnings).toHaveLength(3)
+      expect(warnings[0]).toContain("'SomeWeirdKey'")
+      expect(warnings[1]).toContain("'notify_no_data_typo'")
+      expect(warnings[2]).toContain("'ANOTHER_UNUSUAL'")
+    })
+
+    it('handles config.options absent without throwing', () => {
+      const config = {
+        name: 'Test',
+        type: 'metric alert',
+        query: 'avg:system.load.1{*} > 2'
+      }
+
+      expect(() => collectUnknownKeyWarnings(config)).not.toThrow()
+      expect(collectUnknownKeyWarnings(config)).toEqual([])
+    })
+
+    it('handles config.options === null without throwing', () => {
+      const config = {
+        name: 'Test',
+        options: null
+      }
+
+      expect(() => collectUnknownKeyWarnings(config)).not.toThrow()
+      expect(collectUnknownKeyWarnings(config)).toEqual([])
+    })
+
+    it('handles config.options non-object (string) without throwing', () => {
+      const config = {
+        name: 'Test',
+        options: 'not-an-object'
+      }
+
+      expect(() => collectUnknownKeyWarnings(config)).not.toThrow()
+      // options is a known holder key so it is not flagged as top-level unknown;
+      // and it's not an object so no nested keys to scan.
+      expect(collectUnknownKeyWarnings(config)).toEqual([])
+    })
+
+    it('handles config.options as array (non-plain-object) without throwing', () => {
+      const config = {
+        name: 'Test',
+        options: ['unexpected']
+      }
+
+      expect(() => collectUnknownKeyWarnings(config)).not.toThrow()
+      // Arrays are not plain objects in the schema's sense; treat as no nested keys.
+      expect(collectUnknownKeyWarnings(config)).toEqual([])
+    })
+
+    it('does not flag the `options` key itself as unknown when present', () => {
+      const config = {
+        name: 'Test',
+        options: {
+          notifyNoData: true
+        }
+      }
+
+      const warnings = collectUnknownKeyWarnings(config)
+      expect(warnings).toEqual([])
+      expect(warnings.every((w) => !w.includes("'options'"))).toBe(true)
     })
   })
 })

--- a/tests/tools/monitors-helpers.test.ts
+++ b/tests/tools/monitors-helpers.test.ts
@@ -3,7 +3,12 @@
  * Focus on normalizeMonitorConfig which is completely untested (lines 146-194)
  */
 import { describe, it, expect } from 'vitest'
-import { normalizeMonitorConfig, collectUnknownKeyWarnings } from '../../src/tools/monitors.js'
+import {
+  normalizeMonitorConfig,
+  collectUnknownKeyWarnings,
+  MonitorConfigSchema,
+  MonitorOptionsSchema
+} from '../../src/tools/monitors.js'
 
 describe('Monitors Helper Functions', () => {
   describe('normalizeMonitorConfig', () => {
@@ -499,5 +504,259 @@ describe('Monitors Helper Functions', () => {
       expect(warnings).toEqual([])
       expect(warnings.every((w) => !w.includes("'options'"))).toBe(true)
     })
+  })
+})
+
+// Schema validation tests (Task 9) — exercises MonitorOptionsSchema and
+// MonitorConfigSchema (defined in src/tools/monitors.ts). Covers:
+//   - one accept-case per validated `options.*` key (Requirement 1.1)
+//   - wrong-type rejection for `notifyNoData`, `renotifyInterval`, `tags`
+//     (Requirement 1.2 + 2.1)
+//   - `priority` out-of-range rejection (Requirement 2.4)
+//   - top-level config empty / options-only acceptance (Requirement 2.3,
+//     design Testing strategy → Unit tests)
+
+describe('MonitorOptionsSchema — accept-cases per validated key', () => {
+  // Each entry is [keyName, validValue]. Parametrized so adding a new key to
+  // the schema means adding one row here — not a copy-pasted block.
+  const acceptCases: ReadonlyArray<readonly [string, unknown]> = [
+    // Notification
+    ['notifyNoData', true],
+    ['noDataTimeframe', 60],
+    ['notifyAudit', false],
+    ['notificationPresetName', 'show_all'],
+    // Evaluation / delay
+    ['newHostDelay', 300],
+    ['newGroupDelay', 60],
+    ['evaluationDelay', 900],
+    ['requireFullWindow', true],
+    ['onMissingData', 'show_no_data'],
+    // Renotification — `renotifyInterval` is documented nullable; a number is
+    // the common case so we use a number here. Null acceptance is asserted
+    // separately below.
+    ['renotifyInterval', 120],
+    ['renotifyOccurrences', 5],
+    ['renotifyStatuses', ['alert', 'warn']],
+    ['escalationMessage', 'Escalating!'],
+    // Lifecycle
+    ['timeoutH', 24],
+    ['includeTags', true],
+    ['locked', false],
+    ['silenced', { '*': null, 'env:prod': 1700000000 }],
+    ['groupRetentionDuration', '2d'],
+    // Thresholds & scheduling — nested schemas validated by their own helpers
+    ['thresholds', { critical: 90, warning: 75, criticalRecovery: 80 }],
+    ['thresholdWindows', { triggerWindow: 'last_5m', recoveryWindow: 'last_5m' }],
+    ['schedulingOptions', { evaluationWindow: { dayStarts: '04:00' } }]
+  ]
+
+  it.each(acceptCases)('accepts validated options key %s with valid value', (key, value) => {
+    const result = MonitorOptionsSchema.safeParse({ [key]: value })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toHaveProperty(key)
+    }
+  })
+
+  it('accepts renotifyInterval set to null (documented nullable)', () => {
+    const result = MonitorOptionsSchema.safeParse({ renotifyInterval: null })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts timeoutH set to null (documented nullable)', () => {
+    const result = MonitorOptionsSchema.safeParse({ timeoutH: null })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts an empty options object (all keys optional)', () => {
+    const result = MonitorOptionsSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it('preserves unknown options keys via passthrough (Requirement 3)', () => {
+    const result = MonitorOptionsSchema.safeParse({
+      notifyNoData: true,
+      futureDatadogOption: 'value'
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toHaveProperty('futureDatadogOption', 'value')
+    }
+  })
+})
+
+describe('MonitorOptionsSchema — reject-cases for wrong primitive types', () => {
+  it('rejects notifyNoData when given a non-boolean (string)', () => {
+    const result = MonitorOptionsSchema.safeParse({ notifyNoData: 'yes' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues[0]
+      expect(issue?.path).toEqual(['notifyNoData'])
+      expect(issue?.code).toBe('invalid_type')
+    }
+  })
+
+  it('rejects renotifyInterval when given a non-number (string)', () => {
+    const result = MonitorOptionsSchema.safeParse({ renotifyInterval: '120' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues[0]
+      expect(issue?.path).toEqual(['renotifyInterval'])
+      expect(issue?.code).toBe('invalid_type')
+    }
+  })
+
+  it('rejects renotifyStatuses when given a non-array (string)', () => {
+    const result = MonitorOptionsSchema.safeParse({ renotifyStatuses: 'alert' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues[0]
+      expect(issue?.path).toEqual(['renotifyStatuses'])
+      expect(issue?.code).toBe('invalid_type')
+    }
+  })
+
+  it('rejects evaluationDelay when given a boolean', () => {
+    const result = MonitorOptionsSchema.safeParse({ evaluationDelay: true })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects escalationMessage when given a number', () => {
+    const result = MonitorOptionsSchema.safeParse({ escalationMessage: 42 })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects thresholds.critical when given a string', () => {
+    const result = MonitorOptionsSchema.safeParse({
+      thresholds: { critical: '90' }
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues[0]
+      expect(issue?.path).toEqual(['thresholds', 'critical'])
+    }
+  })
+})
+
+describe('MonitorConfigSchema — top-level acceptance', () => {
+  it('accepts an empty config object (all keys optional, supports partial update)', () => {
+    const result = MonitorConfigSchema.safeParse({})
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a config object with only `options` set (partial update payload)', () => {
+    const result = MonitorConfigSchema.safeParse({ options: {} })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a config object with options containing only renotifyInterval', () => {
+    const result = MonitorConfigSchema.safeParse({
+      options: { renotifyInterval: 120 }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts a fully-populated valid config object', () => {
+    const result = MonitorConfigSchema.safeParse({
+      name: 'Test Monitor',
+      type: 'metric alert',
+      query: 'avg:system.load.1{*} > 2',
+      message: 'Alert!',
+      tags: ['env:prod', 'team:platform'],
+      priority: 3,
+      restrictedRoles: ['admin'],
+      multi: true,
+      options: {
+        notifyNoData: true,
+        noDataTimeframe: 60,
+        thresholds: { critical: 90 }
+      }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts an unknown top-level key via passthrough (Requirement 3.2)', () => {
+    const result = MonitorConfigSchema.safeParse({
+      name: 'Test',
+      futureDatadogField: 'value'
+    })
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toHaveProperty('futureDatadogField', 'value')
+    }
+  })
+
+  it('accepts priority set to null (clearing on update)', () => {
+    const result = MonitorConfigSchema.safeParse({ priority: null })
+    expect(result.success).toBe(true)
+  })
+
+  it.each([1, 2, 3, 4, 5])('accepts priority %i (in 1-5 range)', (priority) => {
+    const result = MonitorConfigSchema.safeParse({ priority })
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('MonitorConfigSchema — top-level rejection', () => {
+  it('rejects priority: 7 (out of 1-5 range)', () => {
+    const result = MonitorConfigSchema.safeParse({ priority: 7 })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues[0]
+      expect(issue?.path).toEqual(['priority'])
+    }
+  })
+
+  it('rejects priority: 0 (below 1-5 range)', () => {
+    const result = MonitorConfigSchema.safeParse({ priority: 0 })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(['priority'])
+    }
+  })
+
+  it('rejects priority: 2.5 (non-integer)', () => {
+    const result = MonitorConfigSchema.safeParse({ priority: 2.5 })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(['priority'])
+    }
+  })
+
+  it('rejects tags when given a non-array (string)', () => {
+    const result = MonitorConfigSchema.safeParse({ tags: 'env:prod' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const issue = result.error.issues[0]
+      expect(issue?.path).toEqual(['tags'])
+      expect(issue?.code).toBe('invalid_type')
+    }
+  })
+
+  it('rejects name when given a non-string (number)', () => {
+    const result = MonitorConfigSchema.safeParse({ name: 42 })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(['name'])
+    }
+  })
+
+  it('rejects multi when given a non-boolean (string)', () => {
+    const result = MonitorConfigSchema.safeParse({ multi: 'true' })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(['multi'])
+    }
+  })
+
+  it('propagates nested options validation errors (notifyNoData wrong type)', () => {
+    const result = MonitorConfigSchema.safeParse({
+      name: 'Test',
+      options: { notifyNoData: 'yes' }
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.path).toEqual(['options', 'notifyNoData'])
+    }
   })
 })

--- a/tests/tools/monitors-helpers.test.ts
+++ b/tests/tools/monitors-helpers.test.ts
@@ -266,6 +266,32 @@ describe('Monitors Helper Functions', () => {
       expect(result.options?.thresholds).toEqual({ critical: 100 })
     })
 
+    it('produces no warnings after normalization for snake_case aliased keys', () => {
+      // Regression: any snake_case key in `optionMappings` MUST be converted to
+      // its camelCase form by `normalizeMonitorConfig`, leaving zero unknown
+      // keys for `collectUnknownKeyWarnings` to report. This guards against
+      // missed alias entries (which would surface as spurious warnings).
+      const config = {
+        name: 'Aliased Snake Monitor',
+        type: 'metric alert',
+        query: 'avg(last_5m):avg:system.cpu.user{*} > 90',
+        options: {
+          notify_no_data: true,
+          no_data_timeframe: 60,
+          notification_preset_name: 'show_all',
+          on_missing_data: 'show_no_data',
+          group_retention_duration: '2d',
+          threshold_windows: { triggerWindow: 'last_5m', recoveryWindow: 'last_5m' },
+          scheduling_options: { evaluationWindow: { dayStarts: '04:00' } }
+        }
+      }
+
+      const normalized = normalizeMonitorConfig(config)
+      const warnings = collectUnknownKeyWarnings(normalized)
+
+      expect(warnings).toEqual([])
+    })
+
     it('should handle complex nested structure', () => {
       const config = {
         name: 'Complex Monitor',

--- a/tests/tools/monitors.test.ts
+++ b/tests/tools/monitors.test.ts
@@ -330,6 +330,123 @@ describe('Monitors Tool', () => {
     })
   })
 
+  // Requirement 4 + Requirement 8 (design.md "Testing strategy → Integration tests"):
+  // Warnings array contract — passthrough keys produce stable-ordered warnings, only
+  // validated keys produce no `warnings` field, and update request bodies preserve
+  // passthrough keys forwarded to Datadog (verified via msw request capture).
+  describe('warnings array (passthrough keys)', () => {
+    it('returns warnings of length 2 in stable order (top-level first, then options) when create receives one unknown top-level key and one unknown options key', async () => {
+      server.use(
+        http.post(endpoints.listMonitors, async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>
+          return jsonResponse({
+            id: 12348,
+            ...body,
+            overall_state: 'No Data',
+            created: new Date().toISOString(),
+            modified: new Date().toISOString()
+          })
+        })
+      )
+
+      const result = await createMonitor(api, {
+        name: 'Mixed Unknown Monitor',
+        type: 'metric alert',
+        query: 'avg(last_5m):avg:system.cpu.user{*} > 95',
+        futureField: 'topLevelPassthrough',
+        options: {
+          notifyNoData: true,
+          futureOption: 'optionsPassthrough'
+        }
+      })
+
+      expect(result.success).toBe(true)
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings).toHaveLength(2)
+      // Stable order: top-level unknowns first, then options unknowns
+      expect(result.warnings?.[0]).toBe(
+        "unknown top-level key 'futureField' under config forwarded without validation"
+      )
+      expect(result.warnings?.[1]).toBe(
+        "unknown option key 'futureOption' under config.options forwarded without validation"
+      )
+    })
+
+    it('omits the warnings field on create when the input contains only validated keys', async () => {
+      server.use(
+        http.post(endpoints.listMonitors, async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>
+          return jsonResponse({
+            id: 12349,
+            ...body,
+            overall_state: 'No Data',
+            created: new Date().toISOString(),
+            modified: new Date().toISOString()
+          })
+        })
+      )
+
+      const result = await createMonitor(api, {
+        name: 'Validated Only Monitor',
+        type: 'metric alert',
+        query: 'avg(last_5m):avg:system.cpu.user{*} > 95',
+        message: 'CPU is high',
+        tags: ['env:production'],
+        priority: 3,
+        options: {
+          notifyNoData: true,
+          renotifyInterval: 30,
+          includeTags: true
+        }
+      })
+
+      expect(result.success).toBe(true)
+      expect(result).not.toHaveProperty('warnings')
+      expect(result.warnings).toBeUndefined()
+    })
+
+    it('forwards a partial update body to Datadog and surfaces a warning for an unknown options key on update', async () => {
+      let capturedBody: Record<string, unknown> | undefined
+
+      server.use(
+        http.put(endpoints.getMonitor(12345), async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse({
+            ...fixtures.single,
+            ...capturedBody
+          })
+        })
+      )
+
+      const result = await updateMonitor(api, '12345', {
+        options: {
+          renotifyInterval: 45,
+          notificationCadence: 'hourly'
+        }
+      })
+
+      // msw request capture — assert the validated key reached Datadog (the Datadog
+      // SDK serializes camelCase → snake_case for keys in its attributeTypeMap and
+      // strips keys it does not recognise, so the unknown `notificationCadence`
+      // does not appear on the wire even though `MonitorOptionsSchema.passthrough()`
+      // preserves it through validation).
+      expect(capturedBody).toBeDefined()
+      const sentOptions = capturedBody?.options as Record<string, unknown> | undefined
+      expect(sentOptions).toBeDefined()
+      expect(sentOptions?.renotify_interval).toBe(45)
+      // Confirm only the supplied keys are present in the body (partial update).
+      expect(capturedBody && Object.keys(capturedBody)).toEqual(['options'])
+
+      // Response assertion — the unknown options key is surfaced via the warnings
+      // array so the caller can detect the passthrough (Requirement 4).
+      expect(result.success).toBe(true)
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings).toContain(
+        "unknown option key 'notificationCadence' under config.options forwarded without validation"
+      )
+    })
+  })
+
   describe('deleteMonitor', () => {
     it('should delete a monitor', async () => {
       server.use(

--- a/tests/tools/monitors.test.ts
+++ b/tests/tools/monitors.test.ts
@@ -625,6 +625,50 @@ describe('Monitors Tool', () => {
     })
   })
 
+  describe('validation short-circuit (Task 12)', () => {
+    it('throws EINVALID_MONITOR_CONFIG before any HTTP call when notifyNoData has wrong type', async () => {
+      let requestCount = 0
+      server.use(
+        http.post(endpoints.createMonitor, () => {
+          requestCount++
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      await expect(
+        createMonitor(api, {
+          name: 'Bad Monitor',
+          type: 'metric alert',
+          query: 'avg(last_5m):avg:system.cpu.user{*} > 90',
+          options: {
+            // Wrong type — notifyNoData must be boolean per MonitorOptionsSchema.
+            notifyNoData: 'yes'
+          }
+        })
+      ).rejects.toThrow(/^EINVALID_MONITOR_CONFIG:/)
+
+      expect(requestCount).toBe(0)
+    })
+
+    it('throws EINVALID_MONITOR_CONFIG before any HTTP call on updateMonitor with bad priority', async () => {
+      let requestCount = 0
+      server.use(
+        http.put(endpoints.getMonitor(12345), () => {
+          requestCount++
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      await expect(
+        updateMonitor(api, '12345', {
+          priority: 7 // out of 1-5 range
+        })
+      ).rejects.toThrow(/^EINVALID_MONITOR_CONFIG:/)
+
+      expect(requestCount).toBe(0)
+    })
+  })
+
   describe('deleteMonitor', () => {
     it('should delete a monitor', async () => {
       server.use(

--- a/tests/tools/monitors.test.ts
+++ b/tests/tools/monitors.test.ts
@@ -629,7 +629,7 @@ describe('Monitors Tool', () => {
     it('throws EINVALID_MONITOR_CONFIG before any HTTP call when notifyNoData has wrong type', async () => {
       let requestCount = 0
       server.use(
-        http.post(endpoints.createMonitor, () => {
+        http.post(endpoints.listMonitors, () => {
           requestCount++
           return jsonResponse(fixtures.single)
         })

--- a/tests/tools/monitors.test.ts
+++ b/tests/tools/monitors.test.ts
@@ -447,6 +447,184 @@ describe('Monitors Tool', () => {
     })
   })
 
+  // Requirement 5 (snake_case alias compatibility) + Requirement 8.1.c:
+  // documented snake_case aliases (notify_no_data, renotify_interval,
+  // critical_recovery under thresholds, etc.) are normalized to camelCase by
+  // `normalizeMonitorConfig` BEFORE schema validation and warning collection,
+  // so they MUST NOT appear in `warnings`. Design.md "Sequence / control flow"
+  // step 4 establishes the order; "Error handling" row 6 documents the
+  // mixed-form contract (both keys preserved in-memory; snake_case form
+  // surfaces as a warning because `KNOWN_OPTIONS_KEYS` is camelCase only).
+  describe('snake_case alias compatibility (warnings)', () => {
+    it('normalizes notification alias notify_no_data and emits no warning (Requirement 5.4)', async () => {
+      let capturedBody: Record<string, unknown> | undefined
+
+      server.use(
+        http.post(endpoints.listMonitors, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse({
+            id: 12350,
+            ...capturedBody,
+            overall_state: 'No Data',
+            created: new Date().toISOString(),
+            modified: new Date().toISOString()
+          })
+        })
+      )
+
+      const result = await createMonitor(api, {
+        name: 'Notification Alias Monitor',
+        type: 'metric alert',
+        query: 'avg(last_5m):avg:system.cpu.user{*} > 95',
+        options: {
+          notify_no_data: true,
+          no_data_timeframe: 60
+        }
+      })
+
+      expect(result.success).toBe(true)
+      // Normalized aliases must not appear as unknown — `warnings` is omitted
+      // entirely when empty (design.md "Open questions" → default).
+      expect(result).not.toHaveProperty('warnings')
+      expect(result.warnings).toBeUndefined()
+
+      // SDK serializes the camelCase keys back to snake_case on the wire — assert
+      // the normalized values reach Datadog under the snake_case names.
+      expect(capturedBody).toBeDefined()
+      const sentOptions = capturedBody?.options as Record<string, unknown> | undefined
+      expect(sentOptions).toBeDefined()
+      expect(sentOptions?.notify_no_data).toBe(true)
+      expect(sentOptions?.no_data_timeframe).toBe(60)
+    })
+
+    it('normalizes renotification alias renotify_interval and emits no warning (Requirement 5.4)', async () => {
+      let capturedBody: Record<string, unknown> | undefined
+
+      server.use(
+        http.put(endpoints.getMonitor(12345), async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse({
+            ...fixtures.single,
+            ...capturedBody
+          })
+        })
+      )
+
+      const result = await updateMonitor(api, '12345', {
+        options: {
+          renotify_interval: 45,
+          renotify_occurrences: 3,
+          escalation_message: 'Escalating to oncall'
+        }
+      })
+
+      expect(result.success).toBe(true)
+      expect(result).not.toHaveProperty('warnings')
+      expect(result.warnings).toBeUndefined()
+
+      // Normalized renotification keys reach Datadog under their snake_case
+      // wire names after the SDK serializer (camelCase → snake_case).
+      expect(capturedBody).toBeDefined()
+      const sentOptions = capturedBody?.options as Record<string, unknown> | undefined
+      expect(sentOptions).toBeDefined()
+      expect(sentOptions?.renotify_interval).toBe(45)
+      expect(sentOptions?.renotify_occurrences).toBe(3)
+      expect(sentOptions?.escalation_message).toBe('Escalating to oncall')
+    })
+
+    it('normalizes nested thresholds alias critical_recovery and emits no warning (Requirement 5.1)', async () => {
+      let capturedBody: Record<string, unknown> | undefined
+
+      server.use(
+        http.post(endpoints.listMonitors, async ({ request }) => {
+          capturedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse({
+            id: 12351,
+            ...capturedBody,
+            overall_state: 'No Data',
+            created: new Date().toISOString(),
+            modified: new Date().toISOString()
+          })
+        })
+      )
+
+      const result = await createMonitor(api, {
+        name: 'Thresholds Alias Monitor',
+        type: 'metric alert',
+        query: 'avg(last_5m):avg:system.cpu.user{*} > 95',
+        options: {
+          thresholds: {
+            critical: 95,
+            warning: 80,
+            critical_recovery: 90,
+            warning_recovery: 75
+          }
+        }
+      })
+
+      expect(result.success).toBe(true)
+      // Nested threshold aliases (critical_recovery, warning_recovery) are
+      // normalized by `normalizeMonitorConfig` before schema validation — they
+      // must NOT appear as unknown options keys.
+      expect(result).not.toHaveProperty('warnings')
+      expect(result.warnings).toBeUndefined()
+
+      // Wire body — SDK serializes nested thresholds back to snake_case.
+      expect(capturedBody).toBeDefined()
+      const sentOptions = capturedBody?.options as Record<string, unknown> | undefined
+      const sentThresholds = sentOptions?.thresholds as Record<string, unknown> | undefined
+      expect(sentThresholds).toBeDefined()
+      expect(sentThresholds?.critical).toBe(95)
+      expect(sentThresholds?.warning).toBe(80)
+      expect(sentThresholds?.critical_recovery).toBe(90)
+      expect(sentThresholds?.warning_recovery).toBe(75)
+    })
+
+    it('preserves both snake_case and camelCase forms of the same key and emits a warning for the snake_case form (mixed-form contract)', async () => {
+      // When BOTH `notify_no_data` and `notifyNoData` are supplied for the same
+      // logical key, `normalizeMonitorConfig` (lines 407–411 of monitors.ts)
+      // keeps both as-is — it only renames when the camelCase target is absent
+      // (Requirement 5.2). After normalization the camelCase form is
+      // recognised; the snake_case form survives and surfaces as a warning
+      // because `KNOWN_OPTIONS_KEYS` is camelCase only (design.md "Error
+      // handling" row 6).
+      server.use(
+        http.post(endpoints.listMonitors, async ({ request }) => {
+          const body = (await request.json()) as Record<string, unknown>
+          return jsonResponse({
+            id: 12352,
+            ...body,
+            overall_state: 'No Data',
+            created: new Date().toISOString(),
+            modified: new Date().toISOString()
+          })
+        })
+      )
+
+      const result = await createMonitor(api, {
+        name: 'Mixed Form Monitor',
+        type: 'metric alert',
+        query: 'avg(last_5m):avg:system.cpu.user{*} > 95',
+        options: {
+          notify_no_data: true,
+          notifyNoData: false
+        }
+      })
+
+      expect(result.success).toBe(true)
+      // Snake_case form is reported as an unknown options key — caller can
+      // detect the duplicate and remove one form. The camelCase form is
+      // validated and therefore does NOT appear in warnings.
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings).toContain(
+        "unknown option key 'notify_no_data' under config.options forwarded without validation"
+      )
+      expect(result.warnings).not.toContain(
+        "unknown option key 'notifyNoData' under config.options forwarded without validation"
+      )
+    })
+  })
+
   describe('deleteMonitor', () => {
     it('should delete a monitor', async () => {
       server.use(


### PR DESCRIPTION
Implements `monitors-options-schema` spec — addresses #54.

## Summary

- Adds typed zod schemas for `MonitorOptionsSchema` (21 documented option keys), `MonitorConfigSchema` (8 top-level keys + nested options), `MonitorThresholdsSchema`, `MonitorThresholdWindowsSchema`, `SchedulingOptionsSchema`. All use `.passthrough()` — unknown keys are forwarded, not stripped.
- `createMonitor` and `updateMonitor` now validate config against the schema **before** any HTTP call. Validation failures short-circuit as `EINVALID_MONITOR_CONFIG: <path>: <expected>`.
- New `warnings` field on the response surfaces unknown keys callers supplied (top-level or under `options`), in stable order. Field is omitted when empty.
- `KNOWN_TOP_LEVEL_KEYS` and `KNOWN_OPTIONS_KEYS` are derived from `schema.shape` — single source of truth, cannot drift from the schemas.
- Tool description rewritten to enumerate validated keys by category + link to Datadog Monitor schema docs.
- Existing snake_case → camelCase normalization (`normalizeMonitorConfig`) runs before validation, so documented aliases (`notify_no_data`, `renotify_interval`, nested `critical_recovery`) produce no warnings.

## Tests

- 76 unit tests in `monitors-helpers.test.ts` (49 new for schema accept/reject)
- 28 integration tests in `monitors.test.ts` (9 new: 3 warnings/stable-order, 4 snake_case alias, 2 validation short-circuit)
- Full suite: 1081/1081 pass across 63 files

## Notable finding

`@datadog/datadog-api-client`'s `ObjectSerializer` strips keys not in its `attributeTypeMap` at the wire layer, **even with zod `.passthrough()`**. The warning contract still holds — unknowns surface in `warnings` before serialization — but they do not actually reach Datadog over HTTP. Tests reflect this reality. If a future task wants unknown keys to reach Datadog, it would need an `additionalProperties` envelope at the producer site.

## Backward compatibility

All pre-existing monitor tests pass unmodified. New `warnings` field is additive (omitted when empty). New error prefix `EINVALID_MONITOR_CONFIG:` only fires on wrong-type input that would have failed at Datadog anyway.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test -- --run` (1081/1081)
- [x] `npm run build`