### PR TITLE
feat(logs): pipelines, indexes, archives config tools (#50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,15 @@ When running with `--transport=http`:
 | `dashboards` | delete | Visualization | Delete a dashboard | `dashboards_write` |
 | `logs` | search | Logs | Search logs with query syntax and filters | `logs_read_data`, `logs_read_index_data` |
 | `logs` | aggregate | Logs | Aggregate log data with groupBy | `logs_read_data` |
+| `logs_pipelines` | list, get | Logs Config | Inspect log processing pipelines and their processors | `logs_read_config` |
+| `logs_pipelines` | create, update, delete, reorder | Logs Config | Author pipelines and processor chains | `logs_write_config` |
+| `logs_pipelines` | get_order | Logs Config | Read pipeline evaluation order | `logs_read_config` |
+| `logs_indexes` | list, get | Logs Config | Inspect indexes (filter, retention, Flex tier, exclusion filters); `create`/`delete` are UI-only per Datadog and not exposed | `logs_read_config` |
+| `logs_indexes` | update, reorder | Logs Config | Update index filter/retention/quota and reorder evaluation | `logs_write_config` |
+| `logs_indexes` | get_order | Logs Config | Read index evaluation order | `logs_read_config` |
+| `logs_archives` | list, get | Logs Config | Inspect log archives (S3 / GCS / Azure destinations); per-provider credential fields are forwarded unchanged | `logs_read_archives` |
+| `logs_archives` | create, update, delete, reorder | Logs Config | Manage archive destinations; `destination.type` validated against `s3 | gcs | azure_storage` before SDK call | `logs_write_archives` |
+| `logs_archives` | get_order | Logs Config | Read archive evaluation order | `logs_read_archives` |
 | `metrics` | query | Metrics | Query timeseries data | `metrics_read`, `timeseries_query` |
 | `metrics` | search | Metrics | Search for metrics by name | `metrics_read` |
 | `metrics` | list | Metrics | List active metrics | `metrics_read` |

--- a/src/config/datadog.ts
+++ b/src/config/datadog.ts
@@ -25,6 +25,9 @@ export interface DatadogClients {
   spans: v2.SpansApi
   services: v2.ServiceDefinitionApi
   auth: v1.AuthenticationApi
+  logsPipelines: v1.LogsPipelinesApi
+  logsIndexes: v1.LogsIndexesApi
+  logsArchives: v2.LogsArchivesApi
 }
 
 export function createDatadogClients(config: DatadogConfig): DatadogClients {
@@ -72,6 +75,9 @@ export function createDatadogClients(config: DatadogConfig): DatadogClients {
     usage: new v1.UsageMeteringApi(configuration),
     spans: new v2.SpansApi(configuration),
     services: new v2.ServiceDefinitionApi(configuration),
-    auth: new v1.AuthenticationApi(configuration)
+    auth: new v1.AuthenticationApi(configuration),
+    logsPipelines: new v1.LogsPipelinesApi(configuration),
+    logsIndexes: new v1.LogsIndexesApi(configuration),
+    logsArchives: new v2.LogsArchivesApi(configuration)
   }
 }

--- a/src/errors/datadog.ts
+++ b/src/errors/datadog.ts
@@ -102,7 +102,8 @@ const WRITE_ACTIONS = new Set([
   'unmute',
   'cancel',
   'add',
-  'trigger'
+  'trigger',
+  'reorder'
 ])
 
 /**

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -22,6 +22,9 @@ import { registerTagsTool } from './tags.js'
 import { registerUsageTool } from './usage.js'
 import { registerAuthTool } from './auth.js'
 import { registerSchemaTool } from './schema.js'
+import { registerLogsPipelinesTool } from './logs_pipelines.js'
+import { registerLogsIndexesTool } from './logs_indexes.js'
+import { registerLogsArchivesTool } from './logs_archives.js'
 
 export function registerAllTools(
   server: McpServer,
@@ -47,6 +50,12 @@ export function registerAllTools(
   if (enabled('dashboards'))
     registerDashboardsTool(server, clients.dashboards, limits, readOnly, credentials)
   if (enabled('logs')) registerLogsTool(server, clients.logs, limits, site)
+  if (enabled('logs_pipelines'))
+    registerLogsPipelinesTool(server, clients.logsPipelines, limits, readOnly, site)
+  if (enabled('logs_indexes'))
+    registerLogsIndexesTool(server, clients.logsIndexes, limits, readOnly, site)
+  if (enabled('logs_archives'))
+    registerLogsArchivesTool(server, clients.logsArchives, limits, readOnly, site)
   if (enabled('metrics'))
     registerMetricsTool(server, clients.metricsV1, clients.metricsV2, limits, site)
   if (enabled('traces')) registerTracesTool(server, clients.spans, clients.services, limits, site)

--- a/src/tools/logs_archives.ts
+++ b/src/tools/logs_archives.ts
@@ -111,6 +111,13 @@ export function normalizeArchiveConfig(config: Record<string, unknown>): Record<
     throw new Error('destination.type must be one of: s3, gcs, azure_storage')
   }
 
+  // Datadog's wire format expects 'azure', but the tool surface advertises
+  // 'azure_storage' to callers for clarity. Remap on the destination object
+  // after validation so the SDK serializes the correct discriminator.
+  if (destinationType === 'azure_storage') {
+    ;(destination as Record<string, unknown>).type = 'azure'
+  }
+
   return normalized
 }
 

--- a/src/tools/logs_archives.ts
+++ b/src/tools/logs_archives.ts
@@ -1,0 +1,317 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import { v2 } from '@datadog/datadog-api-client'
+import { handleDatadogError, requireParam, checkReadOnly } from '../errors/datadog.js'
+import { toolResult } from '../utils/format.js'
+import { normalizeConfigKeys } from '../utils/normalize.js'
+import type { LimitsConfig } from '../config/schema.js'
+
+const ActionSchema = z.enum(['list', 'get', 'create', 'update', 'delete', 'reorder', 'get_order'])
+
+const InputSchema = {
+  action: ActionSchema.describe('Action to perform'),
+  id: z.string().optional().describe('Archive ID (required for get/update/delete)'),
+  config: z
+    .record(z.unknown())
+    .optional()
+    .describe(
+      'Archive configuration (for create/update). Requires name, query, and destination with type ∈ { s3, gcs, azure_storage }. Provider credential / integration fields are forwarded unchanged.'
+    ),
+  archive_ids: z
+    .array(z.string())
+    .optional()
+    .describe('Ordered archive ID list (required for reorder)'),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe('Return full SDK payload alongside summary (default false)')
+}
+
+const VALID_DESTINATION_TYPES = ['s3', 'gcs', 'azure_storage'] as const
+
+export interface ArchiveSummary {
+  id: string
+  name: string
+  query: string | null
+  destinationType: string
+  destinationContainer: string | null
+  includeTags: boolean
+  rehydrationTags: string[]
+  state: string | null
+  destination?: unknown
+}
+
+/**
+ * Extract the storage container (bucket or Azure container) from a destination.
+ * S3 + GCS expose `bucket`; Azure exposes `container`. Returns null when the
+ * destination is missing or the provider exposes neither field.
+ */
+function extractDestinationContainer(destination: unknown): string | null {
+  if (!destination || typeof destination !== 'object') return null
+  const dest = destination as { bucket?: unknown; container?: unknown }
+  if (typeof dest.bucket === 'string') return dest.bucket
+  if (typeof dest.container === 'string') return dest.container
+  return null
+}
+
+export function formatArchive(
+  archive: v2.LogsArchiveDefinition,
+  verbose: boolean = false
+): ArchiveSummary {
+  const attrs = archive.attributes
+  const destination = attrs?.destination ?? null
+  const destinationType =
+    destination && typeof destination === 'object' && 'type' in destination
+      ? String((destination as { type: unknown }).type ?? '')
+      : ''
+
+  const summary: ArchiveSummary = {
+    id: archive.id ?? '',
+    name: attrs?.name ?? '',
+    query: attrs?.query ?? null,
+    destinationType,
+    destinationContainer: extractDestinationContainer(destination),
+    includeTags: attrs?.includeTags ?? false,
+    rehydrationTags: attrs?.rehydrationTags ?? [],
+    state: (attrs?.state as string | undefined) ?? null
+  }
+  if (verbose && destination) {
+    summary.destination = destination
+  }
+  return summary
+}
+
+/**
+ * Normalize and validate an archive create/update payload.
+ *
+ * - Normalizes snake_case keys recursively (per project convention).
+ * - Validates `name`, `query`, and `destination.type ∈ { s3, gcs, azure_storage }`.
+ * - Forwards per-provider credential / integration fields unchanged so the SDK
+ *   can pass them through to Datadog without local introspection.
+ */
+export function normalizeArchiveConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const normalized = normalizeConfigKeys(config) as Record<string, unknown>
+
+  if (typeof normalized.name !== 'string' || normalized.name.length === 0) {
+    throw new Error("Archive config requires 'name' field")
+  }
+  if (typeof normalized.query !== 'string' || normalized.query.length === 0) {
+    throw new Error("Archive config requires 'query' field")
+  }
+
+  const destination = normalized.destination as { type?: unknown } | undefined
+  if (!destination || typeof destination !== 'object') {
+    throw new Error("Archive config requires 'destination' object")
+  }
+  const destinationType = destination.type
+  if (
+    typeof destinationType !== 'string' ||
+    !VALID_DESTINATION_TYPES.includes(destinationType as (typeof VALID_DESTINATION_TYPES)[number])
+  ) {
+    throw new Error('destination.type must be one of: s3, gcs, azure_storage')
+  }
+
+  return normalized
+}
+
+/**
+ * Build a LogsArchiveCreateRequest body from a normalized config payload.
+ * The destination is forwarded unchanged so provider-specific credential
+ * fields survive round-trip without local validation.
+ */
+function buildArchiveRequestBody(
+  normalizedConfig: Record<string, unknown>
+): v2.LogsArchiveCreateRequest {
+  const { name, query, destination, includeTags, rehydrationTags, rehydrationMaxScanSizeInGb } =
+    normalizedConfig as {
+      name: string
+      query: string
+      destination: unknown
+      includeTags?: unknown
+      rehydrationTags?: unknown
+      rehydrationMaxScanSizeInGb?: unknown
+    }
+
+  const attributes: Record<string, unknown> = {
+    name,
+    query,
+    destination
+  }
+  if (includeTags !== undefined) attributes.includeTags = includeTags
+  if (rehydrationTags !== undefined) attributes.rehydrationTags = rehydrationTags
+  if (rehydrationMaxScanSizeInGb !== undefined) {
+    attributes.rehydrationMaxScanSizeInGb = rehydrationMaxScanSizeInGb
+  }
+
+  return {
+    data: {
+      type: 'archives',
+      attributes
+    }
+  } as unknown as v2.LogsArchiveCreateRequest
+}
+
+export async function listArchives(api: v2.LogsArchivesApi, verbose: boolean = false) {
+  const response = await api.listLogsArchives()
+  const archives = (response.data ?? []).map((archive) => formatArchive(archive, verbose))
+  const result: Record<string, unknown> = { archives, total: archives.length }
+  if (verbose) {
+    result.raw = response
+  }
+  return result
+}
+
+export async function getArchive(api: v2.LogsArchivesApi, id: string, verbose: boolean = false) {
+  const response = await api.getLogsArchive({ archiveId: id })
+  const archive = response.data
+  if (!archive) {
+    throw new Error(`Archive ${id} returned an empty payload`)
+  }
+  const result: Record<string, unknown> = { archive: formatArchive(archive, verbose) }
+  if (verbose) {
+    result.raw = response
+  }
+  return result
+}
+
+export async function createArchive(
+  api: v2.LogsArchivesApi,
+  config: Record<string, unknown>,
+  verbose: boolean = false
+) {
+  const normalized = normalizeArchiveConfig(config)
+  const body = buildArchiveRequestBody(normalized)
+  const response = await api.createLogsArchive({ body })
+  const archive = response.data
+  if (!archive) {
+    throw new Error('Archive creation returned an empty payload')
+  }
+  const result: Record<string, unknown> = {
+    success: true,
+    archive: formatArchive(archive, verbose)
+  }
+  if (verbose) {
+    result.raw = response
+  }
+  return result
+}
+
+export async function updateArchive(
+  api: v2.LogsArchivesApi,
+  id: string,
+  config: Record<string, unknown>,
+  verbose: boolean = false
+) {
+  const normalized = normalizeArchiveConfig(config)
+  const body = buildArchiveRequestBody(normalized)
+  const response = await api.updateLogsArchive({ archiveId: id, body })
+  const archive = response.data
+  if (!archive) {
+    throw new Error(`Archive ${id} update returned an empty payload`)
+  }
+  const result: Record<string, unknown> = {
+    success: true,
+    archive: formatArchive(archive, verbose)
+  }
+  if (verbose) {
+    result.raw = response
+  }
+  return result
+}
+
+export async function deleteArchive(api: v2.LogsArchivesApi, id: string) {
+  await api.deleteLogsArchive({ archiveId: id })
+  return {
+    success: true,
+    message: `Archive ${id} deleted`
+  }
+}
+
+export async function reorderArchives(api: v2.LogsArchivesApi, archiveIds: string[]) {
+  const body = {
+    data: {
+      type: 'archive_order',
+      attributes: {
+        archiveIds
+      }
+    }
+  } as unknown as v2.LogsArchiveOrder
+  const response = await api.updateLogsArchiveOrder({ body })
+  const resultIds =
+    (response.data?.attributes as { archiveIds?: string[] } | undefined)?.archiveIds ?? []
+  return {
+    success: true,
+    order: {
+      archiveIds: resultIds
+    }
+  }
+}
+
+export async function getArchiveOrder(api: v2.LogsArchivesApi) {
+  const response = await api.getLogsArchiveOrder()
+  const resultIds =
+    (response.data?.attributes as { archiveIds?: string[] } | undefined)?.archiveIds ?? []
+  return {
+    order: {
+      archiveIds: resultIds
+    }
+  }
+}
+
+export function registerLogsArchivesTool(
+  server: McpServer,
+  api: v2.LogsArchivesApi,
+  _limits: LimitsConfig,
+  readOnly: boolean = false,
+  _site: string = 'datadoghq.com'
+): void {
+  server.tool(
+    'logs_archives',
+    "Manage Datadog Logs archives (long-term log retention to S3 / GCS / Azure Blob). Actions: list, get, create, update, delete, reorder, get_order. Archives accept destinations of type 's3', 'gcs', or 'azure_storage'; per-provider credential and integration fields (S3 IAM role ARN, GCS service account, Azure tenant/secret) are forwarded unchanged. Mutations (create, update, delete, reorder) are blocked when the server is in read-only mode.",
+    InputSchema,
+    async ({ action, id, config, archive_ids, verbose }) => {
+      try {
+        checkReadOnly(action, readOnly)
+        const isVerbose = verbose ?? false
+        switch (action) {
+          case 'list':
+            return toolResult(await listArchives(api, isVerbose))
+
+          case 'get': {
+            const archiveId = requireParam(id, 'id', 'get')
+            return toolResult(await getArchive(api, archiveId, isVerbose))
+          }
+
+          case 'create': {
+            const archiveConfig = requireParam(config, 'config', 'create')
+            return toolResult(await createArchive(api, archiveConfig, isVerbose))
+          }
+
+          case 'update': {
+            const archiveId = requireParam(id, 'id', 'update')
+            const archiveConfig = requireParam(config, 'config', 'update')
+            return toolResult(await updateArchive(api, archiveId, archiveConfig, isVerbose))
+          }
+
+          case 'delete': {
+            const archiveId = requireParam(id, 'id', 'delete')
+            return toolResult(await deleteArchive(api, archiveId))
+          }
+
+          case 'reorder': {
+            const ids = requireParam(archive_ids, 'archive_ids', 'reorder')
+            return toolResult(await reorderArchives(api, ids))
+          }
+
+          case 'get_order':
+            return toolResult(await getArchiveOrder(api))
+
+          default:
+            throw new Error(`Unknown action: ${String(action)}`)
+        }
+      } catch (error) {
+        handleDatadogError(error)
+      }
+    }
+  )
+}

--- a/src/tools/logs_indexes.ts
+++ b/src/tools/logs_indexes.ts
@@ -1,0 +1,182 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import { v1 } from '@datadog/datadog-api-client'
+import { handleDatadogError, requireParam, checkReadOnly } from '../errors/datadog.js'
+import { toolResult } from '../utils/format.js'
+import { normalizeConfigKeys } from '../utils/normalize.js'
+import type { LimitsConfig } from '../config/schema.js'
+
+const ActionSchema = z.enum(['list', 'get', 'update', 'reorder', 'get_order'])
+
+const InputSchema = {
+  action: ActionSchema.describe('Action to perform'),
+  name: z
+    .string()
+    .optional()
+    .describe('Index name (required for get/update). Datadog identifies indexes by name, not id.'),
+  config: z
+    .record(z.unknown())
+    .optional()
+    .describe(
+      'Index configuration (for update). Requires filter.query and numRetentionDays. Exclusion filters are forwarded unchanged.'
+    ),
+  index_names: z
+    .array(z.string())
+    .optional()
+    .describe('Ordered index name list (required for reorder)'),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe('Return full SDK payload alongside summary (default false)')
+}
+
+export interface IndexSummary {
+  name: string
+  filterQuery: string | null
+  exclusionFiltersCount: number
+  numRetentionDays: number | null
+  numFlexLogsRetentionDays: number | null
+  dailyLimit: number | null
+  isRateLimited: boolean
+  exclusionFilters?: unknown[]
+}
+
+export function formatIndex(idx: v1.LogsIndex, verbose: boolean = false): IndexSummary {
+  const summary: IndexSummary = {
+    name: idx.name ?? '',
+    filterQuery: idx.filter?.query ?? null,
+    exclusionFiltersCount: idx.exclusionFilters?.length ?? 0,
+    numRetentionDays: idx.numRetentionDays ?? null,
+    numFlexLogsRetentionDays: idx.numFlexLogsRetentionDays ?? null,
+    dailyLimit: idx.dailyLimit ?? null,
+    isRateLimited: idx.isRateLimited ?? false
+  }
+  if (verbose && idx.exclusionFilters) {
+    summary.exclusionFilters = idx.exclusionFilters as unknown[]
+  }
+  return summary
+}
+
+/**
+ * Normalize and validate an index update payload.
+ * Datadog's update endpoint requires `filter.query` and `numRetentionDays`.
+ * Unknown fields (exclusion filters, daily limit options) are forwarded unchanged.
+ */
+export function normalizeIndexConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const normalized = normalizeConfigKeys(config) as Record<string, unknown>
+
+  const filter = normalized.filter as { query?: unknown } | undefined
+  if (!filter || typeof filter.query !== 'string' || filter.query.length === 0) {
+    throw new Error("Index config requires 'filter.query' field")
+  }
+  if (typeof normalized.numRetentionDays !== 'number') {
+    throw new Error("Index config requires 'numRetentionDays' field")
+  }
+
+  return normalized
+}
+
+export async function listIndexes(api: v1.LogsIndexesApi, verbose: boolean = false) {
+  const response = await api.listLogIndexes()
+  const indexes = (response.indexes ?? []).map((idx) => formatIndex(idx, verbose))
+  const result: Record<string, unknown> = { indexes, total: indexes.length }
+  if (verbose) {
+    result.raw = response
+  }
+  return result
+}
+
+export async function getIndex(api: v1.LogsIndexesApi, name: string, verbose: boolean = false) {
+  const response = await api.getLogsIndex({ name })
+  const result: Record<string, unknown> = { index: formatIndex(response, verbose) }
+  if (verbose) {
+    result.raw = response
+  }
+  return result
+}
+
+export async function updateIndex(
+  api: v1.LogsIndexesApi,
+  name: string,
+  config: Record<string, unknown>,
+  verbose: boolean = false
+) {
+  const body = normalizeIndexConfig(config) as unknown as v1.LogsIndexUpdateRequest
+  const response = await api.updateLogsIndex({ name, body })
+  const result: Record<string, unknown> = {
+    success: true,
+    index: formatIndex(response, verbose)
+  }
+  if (verbose) {
+    result.raw = response
+  }
+  return result
+}
+
+export async function reorderIndexes(api: v1.LogsIndexesApi, indexNames: string[]) {
+  const body = { indexNames } as v1.LogsIndexesOrder
+  const response = await api.updateLogsIndexOrder({ body })
+  return {
+    success: true,
+    order: {
+      indexNames: response.indexNames ?? []
+    }
+  }
+}
+
+export async function getIndexOrder(api: v1.LogsIndexesApi) {
+  const response = await api.getLogsIndexOrder()
+  return {
+    order: {
+      indexNames: response.indexNames ?? []
+    }
+  }
+}
+
+export function registerLogsIndexesTool(
+  server: McpServer,
+  api: v1.LogsIndexesApi,
+  _limits: LimitsConfig,
+  readOnly: boolean = false,
+  _site: string = 'datadoghq.com'
+): void {
+  server.tool(
+    'logs_indexes',
+    "Manage Datadog Logs indexes (filters, retention, exclusion filters, daily limits). Actions: list, get, update, reorder, get_order. Datadog identifies indexes by 'name', not 'id'. Note: create/delete are UI-only per Datadog and not supported through the API. Mutations (update, reorder) are blocked when the server is in read-only mode.",
+    InputSchema,
+    async ({ action, name, config, index_names, verbose }) => {
+      try {
+        checkReadOnly(action, readOnly)
+        const isVerbose = verbose ?? false
+        switch (action) {
+          case 'list':
+            return toolResult(await listIndexes(api, isVerbose))
+
+          case 'get': {
+            const indexName = requireParam(name, 'name', 'get')
+            return toolResult(await getIndex(api, indexName, isVerbose))
+          }
+
+          case 'update': {
+            const indexName = requireParam(name, 'name', 'update')
+            const indexConfig = requireParam(config, 'config', 'update')
+            return toolResult(await updateIndex(api, indexName, indexConfig, isVerbose))
+          }
+
+          case 'reorder': {
+            const names = requireParam(index_names, 'index_names', 'reorder')
+            return toolResult(await reorderIndexes(api, names))
+          }
+
+          case 'get_order':
+            return toolResult(await getIndexOrder(api))
+
+          default:
+            throw new Error(`Unknown action: ${String(action)}`)
+        }
+      } catch (error) {
+        handleDatadogError(error)
+      }
+    }
+  )
+}

--- a/src/tools/logs_pipelines.ts
+++ b/src/tools/logs_pipelines.ts
@@ -1,0 +1,214 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import { v1 } from '@datadog/datadog-api-client'
+import { handleDatadogError, requireParam, checkReadOnly } from '../errors/datadog.js'
+import { toolResult } from '../utils/format.js'
+import { normalizeConfigKeys } from '../utils/normalize.js'
+import type { LimitsConfig } from '../config/schema.js'
+
+const ActionSchema = z.enum(['list', 'get', 'create', 'update', 'delete', 'reorder', 'get_order'])
+
+const InputSchema = {
+  action: ActionSchema.describe('Action to perform'),
+  id: z.string().optional().describe('Pipeline ID (required for get/update/delete)'),
+  config: z
+    .record(z.unknown())
+    .optional()
+    .describe(
+      'Pipeline configuration (for create/update). Requires name and filter.query. Processors are forwarded unchanged.'
+    ),
+  pipeline_ids: z
+    .array(z.string())
+    .optional()
+    .describe('Ordered pipeline ID list (required for reorder)'),
+  verbose: z
+    .boolean()
+    .optional()
+    .describe('Return full SDK payload alongside summary (default false)')
+}
+
+export interface PipelineSummary {
+  id: string
+  name: string
+  filterQuery: string | null
+  isEnabled: boolean
+  isReadOnly: boolean
+  type: string | null
+  processorsCount: number
+  processors?: unknown[]
+}
+
+export function formatPipeline(p: v1.LogsPipeline, verbose: boolean = false): PipelineSummary {
+  const summary: PipelineSummary = {
+    id: p.id ?? '',
+    name: p.name ?? '',
+    filterQuery: p.filter?.query ?? null,
+    isEnabled: p.isEnabled ?? false,
+    isReadOnly: p.isReadOnly ?? false,
+    type: p.type ?? null,
+    processorsCount: p.processors?.length ?? 0
+  }
+  if (verbose && p.processors) {
+    summary.processors = p.processors as unknown[]
+  }
+  return summary
+}
+
+/**
+ * Normalize and validate a pipeline config payload.
+ * Forwards unknown processor types unchanged so Datadog returns its native
+ * validation error rather than dropping fields silently.
+ */
+export function normalizePipelineConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const normalized = normalizeConfigKeys(config) as Record<string, unknown>
+
+  if (!normalized.name) {
+    throw new Error("Pipeline config requires 'name' field")
+  }
+  const filter = normalized.filter as { query?: unknown } | undefined
+  if (!filter || typeof filter.query !== 'string' || filter.query.length === 0) {
+    throw new Error("Pipeline config requires 'filter.query' field")
+  }
+
+  return normalized
+}
+
+export async function listPipelines(api: v1.LogsPipelinesApi, verbose: boolean = false) {
+  const response = await api.listLogsPipelines()
+  const pipelines = (response ?? []).map((p) => formatPipeline(p, verbose))
+  const result: Record<string, unknown> = { pipelines, total: pipelines.length }
+  if (verbose) {
+    result.raw = response
+  }
+  return result
+}
+
+export async function getPipeline(api: v1.LogsPipelinesApi, id: string, verbose: boolean = false) {
+  const response = await api.getLogsPipeline({ pipelineId: id })
+  const result: Record<string, unknown> = { pipeline: formatPipeline(response, verbose) }
+  if (verbose) {
+    result.raw = response
+  }
+  return result
+}
+
+export async function createPipeline(
+  api: v1.LogsPipelinesApi,
+  config: Record<string, unknown>,
+  verbose: boolean = false
+) {
+  const body = normalizePipelineConfig(config) as unknown as v1.LogsPipeline
+  const response = await api.createLogsPipeline({ body })
+  const result: Record<string, unknown> = {
+    success: true,
+    pipeline: formatPipeline(response, verbose)
+  }
+  if (verbose) {
+    result.raw = response
+  }
+  return result
+}
+
+export async function updatePipeline(
+  api: v1.LogsPipelinesApi,
+  id: string,
+  config: Record<string, unknown>,
+  verbose: boolean = false
+) {
+  const body = normalizeConfigKeys(config) as unknown as v1.LogsPipeline
+  const response = await api.updateLogsPipeline({ pipelineId: id, body })
+  const result: Record<string, unknown> = {
+    success: true,
+    pipeline: formatPipeline(response, verbose)
+  }
+  if (verbose) {
+    result.raw = response
+  }
+  return result
+}
+
+export async function deletePipeline(api: v1.LogsPipelinesApi, id: string) {
+  await api.deleteLogsPipeline({ pipelineId: id })
+  return {
+    success: true,
+    message: `Pipeline ${id} deleted`
+  }
+}
+
+export async function reorderPipelines(api: v1.LogsPipelinesApi, pipelineIds: string[]) {
+  const body = { pipelineIds } as v1.LogsPipelinesOrder
+  const response = await api.updateLogsPipelineOrder({ body })
+  return {
+    success: true,
+    order: {
+      pipelineIds: response.pipelineIds ?? []
+    }
+  }
+}
+
+export async function getPipelineOrder(api: v1.LogsPipelinesApi) {
+  const response = await api.getLogsPipelineOrder()
+  return {
+    order: {
+      pipelineIds: response.pipelineIds ?? []
+    }
+  }
+}
+
+export function registerLogsPipelinesTool(
+  server: McpServer,
+  api: v1.LogsPipelinesApi,
+  _limits: LimitsConfig,
+  readOnly: boolean = false,
+  _site: string = 'datadoghq.com'
+): void {
+  server.tool(
+    'logs_pipelines',
+    "Manage Datadog Logs pipelines (parsing & processor chains). Actions: list, get, create, update, delete, reorder, get_order. Pipelines run sequentially on incoming logs; reorder changes the structure of downstream data. Mutations are blocked when the server is in read-only mode. Unknown processor types in 'config.processors' are forwarded to Datadog unchanged.",
+    InputSchema,
+    async ({ action, id, config, pipeline_ids, verbose }) => {
+      try {
+        checkReadOnly(action, readOnly)
+        const isVerbose = verbose ?? false
+        switch (action) {
+          case 'list':
+            return toolResult(await listPipelines(api, isVerbose))
+
+          case 'get': {
+            const pipelineId = requireParam(id, 'id', 'get')
+            return toolResult(await getPipeline(api, pipelineId, isVerbose))
+          }
+
+          case 'create': {
+            const pipelineConfig = requireParam(config, 'config', 'create')
+            return toolResult(await createPipeline(api, pipelineConfig, isVerbose))
+          }
+
+          case 'update': {
+            const pipelineId = requireParam(id, 'id', 'update')
+            const pipelineConfig = requireParam(config, 'config', 'update')
+            return toolResult(await updatePipeline(api, pipelineId, pipelineConfig, isVerbose))
+          }
+
+          case 'delete': {
+            const pipelineId = requireParam(id, 'id', 'delete')
+            return toolResult(await deletePipeline(api, pipelineId))
+          }
+
+          case 'reorder': {
+            const ids = requireParam(pipeline_ids, 'pipeline_ids', 'reorder')
+            return toolResult(await reorderPipelines(api, ids))
+          }
+
+          case 'get_order':
+            return toolResult(await getPipelineOrder(api))
+
+          default:
+            throw new Error(`Unknown action: ${String(action)}`)
+        }
+      } catch (error) {
+        handleDatadogError(error)
+      }
+    }
+  )
+}

--- a/src/tools/logs_pipelines.ts
+++ b/src/tools/logs_pipelines.ts
@@ -115,7 +115,9 @@ export async function updatePipeline(
   config: Record<string, unknown>,
   verbose: boolean = false
 ) {
-  const body = normalizeConfigKeys(config) as unknown as v1.LogsPipeline
+  // Datadog's PUT is full-replacement: missing required fields produce a
+  // cryptic API error. Validate name + filter.query before the wire call.
+  const body = normalizePipelineConfig(config) as unknown as v1.LogsPipeline
   const response = await api.updateLogsPipeline({ pipelineId: id, body })
   const result: Record<string, unknown> = {
     success: true,

--- a/src/tools/slos.ts
+++ b/src/tools/slos.ts
@@ -5,7 +5,12 @@ import type { SearchServiceLevelObjective } from '@datadog/datadog-api-client/di
 import { handleDatadogError, requireParam, checkReadOnly } from '../errors/datadog.js'
 import { toolResult } from '../utils/format.js'
 import { parseTime, ensureValidTimeRange } from '../utils/time.js'
+import { snakeToCamel, normalizeConfigKeys } from '../utils/normalize.js'
 import type { LimitsConfig } from '../config/schema.js'
+
+// Re-exported so existing public callers (and tests) that import these helpers
+// from '../tools/slos.js' continue to work. Canonical home is '../utils/normalize.js'.
+export { snakeToCamel, normalizeConfigKeys }
 
 const ActionSchema = z.enum(['list', 'get', 'create', 'update', 'delete', 'history'])
 
@@ -154,26 +159,6 @@ export async function getSlo(api: v1.ServiceLevelObjectivesApi, id: string) {
   return {
     slo: response.data ? formatSlo(response.data) : null
   }
-}
-
-/**
- * Recursively convert snake_case keys to camelCase
- */
-export function snakeToCamel(str: string): string {
-  return str.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase())
-}
-
-export function normalizeConfigKeys(obj: unknown): unknown {
-  if (obj === null || obj === undefined) return obj
-  if (Array.isArray(obj)) return obj.map(normalizeConfigKeys)
-  if (typeof obj !== 'object') return obj
-
-  const normalized: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
-    const camelKey = snakeToCamel(key)
-    normalized[camelKey] = normalizeConfigKeys(value)
-  }
-  return normalized
 }
 
 /**

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared key-normalization utilities.
+ *
+ * MCP callers often submit configuration payloads in snake_case (the convention
+ * exposed in tool descriptions and Datadog's REST documentation), while the
+ * `@datadog/datadog-api-client` SDK expects camelCase keys at the model layer.
+ * These helpers bridge that gap without touching the values themselves.
+ *
+ * Consumed by `src/tools/slos.ts` and the Logs configuration tools
+ * (`logs_pipelines`, `logs_indexes`, `logs_archives`). See design.md
+ * "This feature consumes" for the rationale behind lifting these helpers out
+ * of `slos.ts` (tools should not import from each other per structure.md).
+ */
+
+/**
+ * Convert a single snake_case identifier to camelCase.
+ *
+ * Already-camelCase identifiers and single-word identifiers pass through
+ * unchanged because only `_<lowercase>` sequences are rewritten.
+ */
+export function snakeToCamel(str: string): string {
+  return str.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase())
+}
+
+/**
+ * Recursively convert snake_case object keys to camelCase.
+ *
+ * - Primitives, `null`, and `undefined` are returned unchanged.
+ * - Arrays are mapped element-wise (preserving order).
+ * - Objects produce a new object with rewritten keys; values are normalized recursively.
+ *
+ * The input is not mutated.
+ */
+export function normalizeConfigKeys(obj: unknown): unknown {
+  if (obj === null || obj === undefined) return obj
+  if (Array.isArray(obj)) return obj.map(normalizeConfigKeys)
+  if (typeof obj !== 'object') return obj
+
+  const normalized: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const camelKey = snakeToCamel(key)
+    normalized[camelKey] = normalizeConfigKeys(value)
+  }
+  return normalized
+}

--- a/src/utils/normalize.ts
+++ b/src/utils/normalize.ts
@@ -5,11 +5,6 @@
  * exposed in tool descriptions and Datadog's REST documentation), while the
  * `@datadog/datadog-api-client` SDK expects camelCase keys at the model layer.
  * These helpers bridge that gap without touching the values themselves.
- *
- * Consumed by `src/tools/slos.ts` and the Logs configuration tools
- * (`logs_pipelines`, `logs_indexes`, `logs_archives`). See design.md
- * "This feature consumes" for the rationale behind lifting these helpers out
- * of `slos.ts` (tools should not import from each other per structure.md).
  */
 
 /**

--- a/tests/config/datadog.test.ts
+++ b/tests/config/datadog.test.ts
@@ -33,7 +33,9 @@ vi.mock('@datadog/datadog-api-client', () => {
       NotebooksApi: MockApi,
       TagsApi: MockApi,
       UsageMeteringApi: MockApi,
-      AuthenticationApi: MockApi
+      AuthenticationApi: MockApi,
+      LogsPipelinesApi: MockApi,
+      LogsIndexesApi: MockApi
     },
     v2: {
       LogsApi: MockApi,
@@ -46,7 +48,8 @@ vi.mock('@datadog/datadog-api-client', () => {
       UsersApi: MockApi,
       TeamsApi: MockApi,
       SpansApi: MockApi,
-      ServiceDefinitionApi: MockApi
+      ServiceDefinitionApi: MockApi,
+      LogsArchivesApi: MockApi
     }
   }
 })
@@ -79,6 +82,8 @@ describe('Datadog Client Creation', () => {
       expect(clients.tags).toBeDefined()
       expect(clients.usage).toBeDefined()
       expect(clients.auth).toBeDefined()
+      expect(clients.logsPipelines).toBeDefined()
+      expect(clients.logsIndexes).toBeDefined()
 
       // Verify all v2 APIs
       expect(clients.logs).toBeDefined()
@@ -89,6 +94,7 @@ describe('Datadog Client Creation', () => {
       expect(clients.rum).toBeDefined()
       expect(clients.security).toBeDefined()
       expect(clients.users).toBeDefined()
+      expect(clients.logsArchives).toBeDefined()
       expect(clients.teams).toBeDefined()
       expect(clients.spans).toBeDefined()
       expect(clients.services).toBeDefined()

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1541,3 +1541,379 @@ export const usage = {
     ]
   }
 }
+
+// Logs Config - Pipelines fixtures (v1)
+// Datadog returns `LogsPipeline[]` directly (no envelope) for the list endpoint.
+export const logsPipelinesFixtures = {
+  list: [
+    {
+      id: 'pipeline-001',
+      name: 'NGINX access logs',
+      type: 'pipeline',
+      is_enabled: true,
+      is_read_only: false,
+      filter: { query: 'source:nginx' },
+      processors: [
+        {
+          type: 'grok-parser',
+          name: 'Parsing NGINX logs',
+          is_enabled: true,
+          source: 'message',
+          samples: [],
+          grok: {
+            support_rules: '',
+            match_rules: 'access_rule %{NUMBER:status}'
+          }
+        },
+        {
+          type: 'date-remapper',
+          name: 'Define date as timestamp',
+          is_enabled: true,
+          sources: ['date']
+        }
+      ]
+    },
+    {
+      id: 'pipeline-002',
+      name: 'Application JSON logs',
+      type: 'pipeline',
+      is_enabled: true,
+      is_read_only: false,
+      filter: { query: 'source:app AND format:json' },
+      processors: [
+        {
+          type: 'attribute-remapper',
+          name: 'Map request_id to trace_id',
+          is_enabled: true,
+          sources: ['request_id'],
+          source_type: 'attribute',
+          target: 'trace_id',
+          target_type: 'attribute',
+          preserve_source: false,
+          override_on_conflict: false
+        }
+      ]
+    },
+    {
+      id: 'pipeline-003',
+      name: 'Datadog integration pipeline',
+      type: 'integration-pipeline',
+      is_enabled: true,
+      is_read_only: true,
+      filter: { query: 'source:datadog-agent' },
+      processors: []
+    }
+  ],
+  single: {
+    id: 'pipeline-001',
+    name: 'NGINX access logs',
+    type: 'pipeline',
+    is_enabled: true,
+    is_read_only: false,
+    filter: { query: 'source:nginx' },
+    processors: [
+      {
+        type: 'grok-parser',
+        name: 'Parsing NGINX logs',
+        is_enabled: true,
+        source: 'message',
+        samples: [],
+        grok: {
+          support_rules: '',
+          match_rules: 'access_rule %{NUMBER:status}'
+        }
+      }
+    ]
+  },
+  created: {
+    id: 'pipeline-new-001',
+    name: 'New Pipeline',
+    type: 'pipeline',
+    is_enabled: true,
+    is_read_only: false,
+    filter: { query: 'service:new-service' },
+    processors: []
+  },
+  updated: {
+    id: 'pipeline-001',
+    name: 'NGINX access logs (updated)',
+    type: 'pipeline',
+    is_enabled: false,
+    is_read_only: false,
+    filter: { query: 'source:nginx AND env:production' },
+    processors: [
+      {
+        type: 'grok-parser',
+        name: 'Parsing NGINX logs',
+        is_enabled: true,
+        source: 'message',
+        samples: [],
+        grok: {
+          support_rules: '',
+          match_rules: 'access_rule %{NUMBER:status}'
+        }
+      }
+    ]
+  },
+  order: {
+    pipeline_ids: ['pipeline-003', 'pipeline-001', 'pipeline-002']
+  }
+}
+
+// Logs Config - Indexes fixtures (v1)
+// Datadog returns `{ indexes: LogsIndex[] }` for the list endpoint.
+export const logsIndexesFixtures = {
+  list: {
+    indexes: [
+      {
+        name: 'main',
+        filter: { query: '*' },
+        num_retention_days: 15,
+        num_flex_logs_retention_days: 360,
+        daily_limit: 1000000000,
+        daily_limit_warning_threshold_percentage: 80,
+        is_rate_limited: false,
+        exclusion_filters: [
+          {
+            name: 'Exclude debug logs',
+            is_enabled: true,
+            filter: {
+              query: 'status:debug',
+              sample_rate: 1.0
+            }
+          },
+          {
+            name: 'Sample health checks',
+            is_enabled: true,
+            filter: {
+              query: 'path:/health',
+              sample_rate: 0.1
+            }
+          }
+        ]
+      },
+      {
+        name: 'security',
+        filter: { query: 'tag:security' },
+        num_retention_days: 30,
+        num_flex_logs_retention_days: 90,
+        daily_limit: 500000000,
+        is_rate_limited: false,
+        exclusion_filters: []
+      },
+      {
+        name: 'low-volume',
+        filter: { query: 'env:staging' },
+        num_retention_days: 7,
+        num_flex_logs_retention_days: 0,
+        daily_limit: 100000000,
+        is_rate_limited: true,
+        exclusion_filters: [
+          {
+            name: 'Drop trace events',
+            is_enabled: false,
+            filter: {
+              query: 'type:trace',
+              sample_rate: 1.0
+            }
+          }
+        ]
+      }
+    ]
+  },
+  single: {
+    name: 'main',
+    filter: { query: '*' },
+    num_retention_days: 15,
+    num_flex_logs_retention_days: 360,
+    daily_limit: 1000000000,
+    daily_limit_warning_threshold_percentage: 80,
+    is_rate_limited: false,
+    exclusion_filters: [
+      {
+        name: 'Exclude debug logs',
+        is_enabled: true,
+        filter: {
+          query: 'status:debug',
+          sample_rate: 1.0
+        }
+      }
+    ]
+  },
+  updated: {
+    name: 'main',
+    filter: { query: '*' },
+    num_retention_days: 30,
+    num_flex_logs_retention_days: 360,
+    daily_limit: 2000000000,
+    is_rate_limited: false,
+    exclusion_filters: [
+      {
+        name: 'Exclude debug logs',
+        is_enabled: true,
+        filter: {
+          query: 'status:debug',
+          sample_rate: 1.0
+        }
+      }
+    ]
+  },
+  order: {
+    index_names: ['main', 'security', 'low-volume']
+  }
+}
+
+// Logs Config - Archives fixtures (v2)
+// v2 envelope: { data: { id, type: 'archives', attributes: {...} } }
+// Note on Azure: Datadog's SDK literal for the destination type is `"azure"` (see
+// `LogsArchiveDestinationAzureType`). The MCP tool layer accepts `"azure_storage"` as the
+// documented public surface and forwards as-is to Datadog; the GET response below uses the
+// SDK literal that the SDK will actually deserialize.
+export const logsArchivesFixtures = {
+  list: {
+    data: [
+      {
+        id: 'archive-s3-001',
+        type: 'archives',
+        attributes: {
+          name: 'Production logs to S3',
+          query: 'env:production',
+          state: 'WORKING',
+          include_tags: true,
+          rehydration_tags: ['source:rehydrated'],
+          rehydration_max_scan_size_in_gb: 100,
+          destination: {
+            type: 's3',
+            bucket: 'company-prod-logs',
+            path: '/datadog',
+            region: 'us-east-1',
+            integration: {
+              account_id: '123456789012',
+              role_name: 'DatadogLogsArchiveRole'
+            }
+          }
+        }
+      },
+      {
+        id: 'archive-gcs-001',
+        type: 'archives',
+        attributes: {
+          name: 'Staging logs to GCS',
+          query: 'env:staging',
+          state: 'WORKING',
+          include_tags: false,
+          rehydration_tags: [],
+          destination: {
+            type: 'gcs',
+            bucket: 'company-staging-logs',
+            path: '/datadog',
+            integration: {
+              client_email: 'datadog-archives@example.iam.gserviceaccount.com',
+              project_id: 'example-project'
+            }
+          }
+        }
+      },
+      {
+        id: 'archive-azure-001',
+        type: 'archives',
+        attributes: {
+          name: 'Audit logs to Azure',
+          query: 'tag:audit',
+          state: 'WORKING',
+          include_tags: true,
+          rehydration_tags: ['source:audit-archive'],
+          destination: {
+            type: 'azure',
+            container: 'datadog-archive',
+            storage_account: 'companyauditlogs',
+            path: '/datadog',
+            region: 'westeurope',
+            integration: {
+              tenant_id: '00000000-0000-0000-0000-000000000000',
+              client_id: '11111111-1111-1111-1111-111111111111'
+            }
+          }
+        }
+      }
+    ]
+  },
+  single: {
+    data: {
+      id: 'archive-s3-001',
+      type: 'archives',
+      attributes: {
+        name: 'Production logs to S3',
+        query: 'env:production',
+        state: 'WORKING',
+        include_tags: true,
+        rehydration_tags: ['source:rehydrated'],
+        rehydration_max_scan_size_in_gb: 100,
+        destination: {
+          type: 's3',
+          bucket: 'company-prod-logs',
+          path: '/datadog',
+          region: 'us-east-1',
+          integration: {
+            account_id: '123456789012',
+            role_name: 'DatadogLogsArchiveRole'
+          }
+        }
+      }
+    }
+  },
+  created: {
+    data: {
+      id: 'archive-new-001',
+      type: 'archives',
+      attributes: {
+        name: 'New Archive',
+        query: 'service:new-service',
+        state: 'WORKING',
+        include_tags: false,
+        rehydration_tags: [],
+        destination: {
+          type: 's3',
+          bucket: 'company-new-archive',
+          path: '/datadog',
+          region: 'eu-west-1',
+          integration: {
+            account_id: '123456789012',
+            role_name: 'DatadogLogsArchiveRole'
+          }
+        }
+      }
+    }
+  },
+  updated: {
+    data: {
+      id: 'archive-s3-001',
+      type: 'archives',
+      attributes: {
+        name: 'Production logs to S3 (updated)',
+        query: 'env:production AND service:api',
+        state: 'WORKING',
+        include_tags: true,
+        rehydration_tags: ['source:rehydrated', 'updated:true'],
+        destination: {
+          type: 's3',
+          bucket: 'company-prod-logs',
+          path: '/datadog/api',
+          region: 'us-east-1',
+          integration: {
+            account_id: '123456789012',
+            role_name: 'DatadogLogsArchiveRole'
+          }
+        }
+      }
+    }
+  },
+  order: {
+    data: {
+      type: 'archive_order',
+      attributes: {
+        archive_ids: ['archive-s3-001', 'archive-gcs-001', 'archive-azure-001']
+      }
+    }
+  }
+}

--- a/tests/helpers/msw.ts
+++ b/tests/helpers/msw.ts
@@ -148,7 +148,33 @@ export const endpoints = {
   getIngestedSpans: `${DD_API_V1}/usage/ingested-spans`,
 
   // Utility Tools - Authentication
-  validateApiKey: `${DD_API_V1}/validate`
+  validateApiKey: `${DD_API_V1}/validate`,
+
+  // Logs Config - Pipelines (v1)
+  listLogsPipelines: `${DD_API_V1}/logs/config/pipelines`,
+  createLogsPipeline: `${DD_API_V1}/logs/config/pipelines`,
+  getLogsPipeline: (id: string) => `${DD_API_V1}/logs/config/pipelines/${id}`,
+  updateLogsPipeline: (id: string) => `${DD_API_V1}/logs/config/pipelines/${id}`,
+  deleteLogsPipeline: (id: string) => `${DD_API_V1}/logs/config/pipelines/${id}`,
+  getLogsPipelineOrder: `${DD_API_V1}/logs/config/pipeline-order`,
+  updateLogsPipelineOrder: `${DD_API_V1}/logs/config/pipeline-order`,
+
+  // Logs Config - Indexes (v1)
+  // Datadog identifies indexes by `name`, not `id`. create/delete are UI-only per Datadog.
+  listLogsIndexes: `${DD_API_V1}/logs/config/indexes`,
+  getLogsIndex: (name: string) => `${DD_API_V1}/logs/config/indexes/${name}`,
+  updateLogsIndex: (name: string) => `${DD_API_V1}/logs/config/indexes/${name}`,
+  getLogsIndexOrder: `${DD_API_V1}/logs/config/index-order`,
+  updateLogsIndexOrder: `${DD_API_V1}/logs/config/index-order`,
+
+  // Logs Config - Archives (v2)
+  listLogsArchives: `${DD_API_V2}/logs/config/archives`,
+  createLogsArchive: `${DD_API_V2}/logs/config/archives`,
+  getLogsArchive: (id: string) => `${DD_API_V2}/logs/config/archives/${id}`,
+  updateLogsArchive: (id: string) => `${DD_API_V2}/logs/config/archives/${id}`,
+  deleteLogsArchive: (id: string) => `${DD_API_V2}/logs/config/archives/${id}`,
+  getLogsArchiveOrder: `${DD_API_V2}/logs/config/archive-order`,
+  updateLogsArchiveOrder: `${DD_API_V2}/logs/config/archive-order`
 }
 
 /**

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -25,6 +25,9 @@ vi.mock('../../src/tools/tags.js', () => ({ registerTagsTool: vi.fn() }))
 vi.mock('../../src/tools/usage.js', () => ({ registerUsageTool: vi.fn() }))
 vi.mock('../../src/tools/auth.js', () => ({ registerAuthTool: vi.fn() }))
 vi.mock('../../src/tools/schema.js', () => ({ registerSchemaTool: vi.fn() }))
+vi.mock('../../src/tools/logs_pipelines.js', () => ({ registerLogsPipelinesTool: vi.fn() }))
+vi.mock('../../src/tools/logs_indexes.js', () => ({ registerLogsIndexesTool: vi.fn() }))
+vi.mock('../../src/tools/logs_archives.js', () => ({ registerLogsArchivesTool: vi.fn() }))
 
 import { registerMonitorsTool } from '../../src/tools/monitors.js'
 import { registerDashboardsTool } from '../../src/tools/dashboards.js'

--- a/tests/tools/index.test.ts
+++ b/tests/tools/index.test.ts
@@ -49,6 +49,9 @@ import { registerTagsTool } from '../../src/tools/tags.js'
 import { registerUsageTool } from '../../src/tools/usage.js'
 import { registerAuthTool } from '../../src/tools/auth.js'
 import { registerSchemaTool } from '../../src/tools/schema.js'
+import { registerLogsPipelinesTool } from '../../src/tools/logs_pipelines.js'
+import { registerLogsIndexesTool } from '../../src/tools/logs_indexes.js'
+import { registerLogsArchivesTool } from '../../src/tools/logs_archives.js'
 
 import type { DatadogConfig } from '../../src/config/schema.js'
 
@@ -86,7 +89,10 @@ describe('Tool Registration', () => {
       users: {} as unknown,
       teams: {} as unknown,
       tags: {} as unknown,
-      usage: {} as unknown
+      usage: {} as unknown,
+      logsPipelines: {} as unknown,
+      logsIndexes: {} as unknown,
+      logsArchives: {} as unknown
     }
     mockLimits = {
       maxResults: 100,
@@ -208,6 +214,27 @@ describe('Tool Registration', () => {
     expect(registerUsageTool).toHaveBeenCalledWith(mockServer, mockClients.usage, mockLimits)
     expect(registerAuthTool).toHaveBeenCalledWith(mockServer, mockClients)
     expect(registerSchemaTool).toHaveBeenCalledWith(mockServer)
+    expect(registerLogsPipelinesTool).toHaveBeenCalledWith(
+      mockServer,
+      mockClients.logsPipelines,
+      mockLimits,
+      false,
+      'datadoghq.com'
+    )
+    expect(registerLogsIndexesTool).toHaveBeenCalledWith(
+      mockServer,
+      mockClients.logsIndexes,
+      mockLimits,
+      false,
+      'datadoghq.com'
+    )
+    expect(registerLogsArchivesTool).toHaveBeenCalledWith(
+      mockServer,
+      mockClients.logsArchives,
+      mockLimits,
+      false,
+      'datadoghq.com'
+    )
   })
 
   it('should not register disabled tools', () => {
@@ -230,6 +257,27 @@ describe('Tool Registration', () => {
     expect(registerDashboardsTool).toHaveBeenCalled()
     expect(registerMetricsTool).toHaveBeenCalled()
     expect(registerEventsTool).toHaveBeenCalled()
+    expect(registerLogsPipelinesTool).toHaveBeenCalled()
+    expect(registerLogsIndexesTool).toHaveBeenCalled()
+    expect(registerLogsArchivesTool).toHaveBeenCalled()
+  })
+
+  it('should not register logs config tools when individually disabled', () => {
+    mockFeatures.disabledTools = ['logs_pipelines', 'logs_indexes', 'logs_archives']
+
+    registerAllTools(
+      mockServer,
+      mockClients,
+      mockLimits,
+      mockFeatures,
+      'datadoghq.com',
+      mockDatadogConfig
+    )
+
+    expect(registerLogsPipelinesTool).not.toHaveBeenCalled()
+    expect(registerLogsIndexesTool).not.toHaveBeenCalled()
+    expect(registerLogsArchivesTool).not.toHaveBeenCalled()
+    expect(registerLogsTool).toHaveBeenCalled()
   })
 
   it('should pass readOnly flag correctly', () => {

--- a/tests/tools/logs_archives.test.ts
+++ b/tests/tools/logs_archives.test.ts
@@ -281,17 +281,41 @@ describe('Logs Archives Tool', () => {
       ).rejects.toThrow('destination.type must be one of: s3, gcs, azure_storage')
     })
 
-    it('should reject destination.type=azure (SDK literal) at the input surface — only azure_storage is accepted', async () => {
-      // The input contract per spec: only 'azure_storage' is accepted as input.
-      // The SDK's own wire literal happens to be 'azure', but the tool surface
-      // does not advertise that — callers must use the discriminator the tool docs.
-      await expect(
-        createArchive(api, {
-          name: 'Azure literal mismatch',
-          query: 'env:production',
-          destination: { type: 'azure', container: 'datadog-archive' }
+    it('should accept destination.type=azure_storage and remap to azure on the wire', async () => {
+      // The input contract per spec: callers submit 'azure_storage' (advertised
+      // in the tool surface). Internally we remap to 'azure' (the SDK / wire
+      // discriminator) before the SDK serializes the body to Datadog.
+      let receivedBody: Record<string, unknown> | undefined
+      server.use(
+        http.post(endpoints.createLogsArchive, async ({ request }) => {
+          receivedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse(fixtures.created)
         })
-      ).rejects.toThrow('destination.type must be one of: s3, gcs, azure_storage')
+      )
+
+      await createArchive(api, {
+        name: 'Azure archive',
+        query: 'env:production',
+        destination: {
+          type: 'azure_storage',
+          container: 'datadog-archive',
+          storage_account: 'mystorage',
+          path: '/datadog',
+          integration: {
+            tenant_id: 'tenant-uuid',
+            client_id: 'client-uuid'
+          }
+        }
+      })
+
+      expect(receivedBody).toBeDefined()
+      const data = receivedBody?.data as Record<string, unknown>
+      const attributes = data?.attributes as Record<string, unknown>
+      const destination = attributes?.destination as Record<string, unknown>
+      // Wire discriminator must be 'azure' (Datadog API expectation), not the
+      // 'azure_storage' value the caller submitted.
+      expect(destination?.type).toBe('azure')
+      expect(destination?.container).toBe('datadog-archive')
     })
 
     it('should propagate 429 rate limit error on create', async () => {

--- a/tests/tools/logs_archives.test.ts
+++ b/tests/tools/logs_archives.test.ts
@@ -1,0 +1,599 @@
+/**
+ * Unit tests for the logs_archives tool.
+ *
+ * Covers each action's happy path, required-field validation on writes,
+ * snake_case normalization on create, destination discriminator validation,
+ * destination round-trip pass-through, 401/403/404/429 error propagation,
+ * read-only enforcement, and verbose payload behavior.
+ *
+ * Requirements covered:
+ *   - Requirement 7 (list / get / create / update / delete / read-only /
+ *     destination discriminator / pass-through / verbose)
+ *   - Requirement 8 (reorder / get_order / read-only)
+ *   - Requirement 10 (testing contract)
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { v2 } from '@datadog/datadog-api-client'
+import { http } from 'msw'
+import { server, endpoints, jsonResponse, errorResponse } from '../helpers/msw.js'
+import { createMockConfig } from '../helpers/mock.js'
+import { logsArchivesFixtures as fixtures } from '../helpers/fixtures.js'
+import {
+  listArchives,
+  getArchive,
+  createArchive,
+  updateArchive,
+  deleteArchive,
+  reorderArchives,
+  getArchiveOrder,
+  registerLogsArchivesTool
+} from '../../src/tools/logs_archives.js'
+import type { LimitsConfig } from '../../src/config/schema.js'
+
+const defaultLimits: LimitsConfig = {
+  maxResults: 100,
+  maxLogLines: 500,
+  maxMetricDataPoints: 1000,
+  defaultTimeRangeHours: 24
+} as unknown as LimitsConfig
+
+describe('Logs Archives Tool', () => {
+  let api: v2.LogsArchivesApi
+
+  beforeEach(() => {
+    const config = createMockConfig()
+    api = new v2.LogsArchivesApi(config)
+  })
+
+  describe('listArchives', () => {
+    it('should list archives with default summary projection (s3, gcs, azure variants)', async () => {
+      server.use(
+        http.get(endpoints.listLogsArchives, () => {
+          return jsonResponse(fixtures.list)
+        })
+      )
+
+      const result = await listArchives(api)
+
+      expect(result.archives).toHaveLength(3)
+      expect(result.total).toBe(3)
+
+      const archives = result.archives as Array<Record<string, unknown>>
+      // S3 variant
+      expect(archives[0]?.id).toBe('archive-s3-001')
+      expect(archives[0]?.name).toBe('Production logs to S3')
+      expect(archives[0]?.query).toBe('env:production')
+      expect(archives[0]?.destinationType).toBe('s3')
+      expect(archives[0]?.destinationContainer).toBe('company-prod-logs')
+      expect(archives[0]?.includeTags).toBe(true)
+      expect(archives[0]?.rehydrationTags).toEqual(['source:rehydrated'])
+      expect(archives[0]?.state).toBe('WORKING')
+      // Default projection omits destination credential blob
+      expect(archives[0]?.destination).toBeUndefined()
+
+      // GCS variant
+      expect(archives[1]?.destinationType).toBe('gcs')
+      expect(archives[1]?.destinationContainer).toBe('company-staging-logs')
+
+      // Azure variant — fixture uses container, not bucket
+      expect(archives[2]?.destinationType).toBe('azure')
+      expect(archives[2]?.destinationContainer).toBe('datadog-archive')
+
+      // Raw payload only appears under verbose.
+      expect(result.raw).toBeUndefined()
+    })
+
+    it('should include the full SDK payload when verbose=true', async () => {
+      server.use(
+        http.get(endpoints.listLogsArchives, () => {
+          return jsonResponse(fixtures.list)
+        })
+      )
+
+      const result = await listArchives(api, true)
+
+      expect(result.archives).toHaveLength(3)
+      const archives = result.archives as Array<Record<string, unknown>>
+      // Destination round-trip surfaces credential / integration fields under verbose.
+      const dest = archives[0]?.destination as Record<string, unknown> | undefined
+      expect(dest).toBeDefined()
+      expect(dest?.type).toBe('s3')
+      expect(dest?.bucket).toBe('company-prod-logs')
+      // Raw payload attached for callers that need fields outside the projection.
+      expect(result.raw).toBeDefined()
+    })
+
+    it('should propagate 401 unauthorized error on list', async () => {
+      server.use(
+        http.get(endpoints.listLogsArchives, () => {
+          return errorResponse(401, 'Invalid API key')
+        })
+      )
+
+      await expect(listArchives(api)).rejects.toMatchObject({ code: 401 })
+    })
+  })
+
+  describe('getArchive', () => {
+    it('should get a single archive by ID', async () => {
+      server.use(
+        http.get(endpoints.getLogsArchive('archive-s3-001'), () => {
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      const result = await getArchive(api, 'archive-s3-001')
+      const archive = result.archive as Record<string, unknown>
+
+      expect(archive.id).toBe('archive-s3-001')
+      expect(archive.name).toBe('Production logs to S3')
+      expect(archive.query).toBe('env:production')
+      expect(archive.destinationType).toBe('s3')
+      expect(archive.destinationContainer).toBe('company-prod-logs')
+    })
+
+    it('should expose full destination under verbose=true', async () => {
+      server.use(
+        http.get(endpoints.getLogsArchive('archive-s3-001'), () => {
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      const result = await getArchive(api, 'archive-s3-001', true)
+      const archive = result.archive as Record<string, unknown>
+      const destination = archive.destination as Record<string, unknown> | undefined
+
+      // Provider integration block survives round-trip via SDK.
+      expect(destination).toBeDefined()
+      expect(destination?.type).toBe('s3')
+      expect(destination?.bucket).toBe('company-prod-logs')
+      expect(result.raw).toBeDefined()
+    })
+
+    it('should propagate 404 not found error on get', async () => {
+      server.use(
+        http.get(endpoints.getLogsArchive('missing'), () => {
+          return errorResponse(404, 'Archive not found')
+        })
+      )
+
+      await expect(getArchive(api, 'missing')).rejects.toMatchObject({ code: 404 })
+    })
+  })
+
+  describe('createArchive', () => {
+    it('should create a new archive with snake_case input normalized (include_tags → includeTags)', async () => {
+      let receivedBody: Record<string, unknown> | undefined
+      server.use(
+        http.post(endpoints.createLogsArchive, async ({ request }) => {
+          receivedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse(fixtures.created)
+        })
+      )
+
+      const result = await createArchive(api, {
+        name: 'New Archive',
+        query: 'service:new-service',
+        destination: {
+          type: 's3',
+          bucket: 'company-new-archive',
+          path: '/datadog',
+          region: 'eu-west-1',
+          integration: {
+            account_id: '123456789012',
+            role_name: 'DatadogLogsArchiveRole'
+          }
+        },
+        include_tags: true,
+        rehydration_tags: ['source:new'],
+        rehydration_max_scan_size_in_gb: 50
+      })
+
+      expect(result.success).toBe(true)
+      const archive = result.archive as Record<string, unknown>
+      expect(archive.id).toBe('archive-new-001')
+      expect(archive.destinationType).toBe('s3')
+
+      // Verify wire payload — SDK serializes camelCase model → snake_case on the wire.
+      // The snake_case normalization in normalizeArchiveConfig flipped include_tags →
+      // includeTags before the SDK; the SDK then serialized it back to include_tags.
+      expect(receivedBody).toBeDefined()
+      const data = receivedBody?.data as Record<string, unknown> | undefined
+      const attributes = data?.attributes as Record<string, unknown> | undefined
+      expect(attributes?.name).toBe('New Archive')
+      expect(attributes?.query).toBe('service:new-service')
+      expect(attributes?.include_tags).toBe(true)
+    })
+
+    it('should pass destination provider credential fields through unchanged (round-trip)', async () => {
+      let receivedBody: Record<string, unknown> | undefined
+      server.use(
+        http.post(endpoints.createLogsArchive, async ({ request }) => {
+          receivedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse(fixtures.created)
+        })
+      )
+
+      await createArchive(api, {
+        name: 'Round-trip S3 Archive',
+        query: 'env:audit',
+        destination: {
+          type: 's3',
+          bucket: 'audit-archive-bucket',
+          path: '/datadog/audit',
+          integration: {
+            account_id: '999999999999',
+            role_name: 'DatadogArchiveRoundtripRole'
+          }
+        }
+      })
+
+      expect(receivedBody).toBeDefined()
+      const data = receivedBody?.data as Record<string, unknown>
+      const attributes = data?.attributes as Record<string, unknown>
+      const destination = attributes?.destination as Record<string, unknown>
+
+      // Destination block forwarded verbatim — type, bucket, path, and integration
+      // credential block survive the SDK boundary without local field-dropping.
+      expect(destination?.type).toBe('s3')
+      expect(destination?.bucket).toBe('audit-archive-bucket')
+      expect(destination?.path).toBe('/datadog/audit')
+      const integration = destination?.integration as Record<string, unknown>
+      expect(integration?.account_id).toBe('999999999999')
+      expect(integration?.role_name).toBe('DatadogArchiveRoundtripRole')
+    })
+
+    it('should throw when name is missing on create', async () => {
+      await expect(
+        createArchive(api, {
+          query: 'env:production',
+          destination: { type: 's3', bucket: 'b' }
+        })
+      ).rejects.toThrow(/name/)
+    })
+
+    it('should throw when query is missing on create', async () => {
+      await expect(
+        createArchive(api, {
+          name: 'No Query Archive',
+          destination: { type: 's3', bucket: 'b' }
+        })
+      ).rejects.toThrow(/query/)
+    })
+
+    it('should throw when destination is missing on create', async () => {
+      await expect(
+        createArchive(api, {
+          name: 'No Destination Archive',
+          query: 'env:production'
+        })
+      ).rejects.toThrow(/destination/)
+    })
+
+    it('should reject destination.type=unknown with discriminator error', async () => {
+      await expect(
+        createArchive(api, {
+          name: 'Bad Destination Archive',
+          query: 'env:production',
+          destination: { type: 'unknown', bucket: 'whatever' }
+        })
+      ).rejects.toThrow('destination.type must be one of: s3, gcs, azure_storage')
+    })
+
+    it('should reject destination.type=azure (SDK literal) at the input surface — only azure_storage is accepted', async () => {
+      // The input contract per spec: only 'azure_storage' is accepted as input.
+      // The SDK's own wire literal happens to be 'azure', but the tool surface
+      // does not advertise that — callers must use the discriminator the tool docs.
+      await expect(
+        createArchive(api, {
+          name: 'Azure literal mismatch',
+          query: 'env:production',
+          destination: { type: 'azure', container: 'datadog-archive' }
+        })
+      ).rejects.toThrow('destination.type must be one of: s3, gcs, azure_storage')
+    })
+
+    it('should propagate 429 rate limit error on create', async () => {
+      server.use(
+        http.post(endpoints.createLogsArchive, () => {
+          return errorResponse(429, 'Rate limit exceeded')
+        })
+      )
+
+      await expect(
+        createArchive(api, {
+          name: 'Rate-limited Archive',
+          query: 'env:production',
+          destination: {
+            type: 's3',
+            bucket: 'rate-limited-bucket',
+            integration: { account_id: '1', role_name: 'r' }
+          }
+        })
+      ).rejects.toMatchObject({ code: 429 })
+    })
+  })
+
+  describe('updateArchive', () => {
+    it('should update an archive and return the updated summary', async () => {
+      let receivedBody: Record<string, unknown> | undefined
+      server.use(
+        http.put(endpoints.updateLogsArchive('archive-s3-001'), async ({ request }) => {
+          receivedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse(fixtures.updated)
+        })
+      )
+
+      const result = await updateArchive(api, 'archive-s3-001', {
+        name: 'Production logs to S3 (updated)',
+        query: 'env:production AND service:api',
+        destination: {
+          type: 's3',
+          bucket: 'company-prod-logs',
+          path: '/datadog/api',
+          region: 'us-east-1',
+          integration: {
+            account_id: '123456789012',
+            role_name: 'DatadogLogsArchiveRole'
+          }
+        },
+        include_tags: true
+      })
+
+      expect(result.success).toBe(true)
+      const archive = result.archive as Record<string, unknown>
+      expect(archive.id).toBe('archive-s3-001')
+      expect(archive.name).toBe('Production logs to S3 (updated)')
+      expect(archive.query).toBe('env:production AND service:api')
+
+      // Wire payload verifies the body was sent.
+      const data = receivedBody?.data as Record<string, unknown>
+      const attributes = data?.attributes as Record<string, unknown>
+      expect(attributes?.name).toBe('Production logs to S3 (updated)')
+      expect(attributes?.include_tags).toBe(true)
+    })
+
+    it('should propagate 403 forbidden error on update', async () => {
+      server.use(
+        http.put(endpoints.updateLogsArchive('archive-s3-001'), () => {
+          return errorResponse(403, 'Insufficient permissions')
+        })
+      )
+
+      await expect(
+        updateArchive(api, 'archive-s3-001', {
+          name: 'Forbidden Update',
+          query: 'env:production',
+          destination: {
+            type: 's3',
+            bucket: 'b',
+            integration: { account_id: '1', role_name: 'r' }
+          }
+        })
+      ).rejects.toMatchObject({ code: 403 })
+    })
+
+    it('should throw when destination.type is invalid on update', async () => {
+      await expect(
+        updateArchive(api, 'archive-s3-001', {
+          name: 'Bad Update',
+          query: 'env:production',
+          destination: { type: 'not-a-valid-type', bucket: 'b' }
+        })
+      ).rejects.toThrow('destination.type must be one of: s3, gcs, azure_storage')
+    })
+  })
+
+  describe('deleteArchive', () => {
+    it('should delete an archive', async () => {
+      server.use(
+        http.delete(endpoints.deleteLogsArchive('archive-s3-001'), () => {
+          return new Response(null, { status: 204 })
+        })
+      )
+
+      const result = await deleteArchive(api, 'archive-s3-001')
+
+      expect(result.success).toBe(true)
+      expect(result.message).toContain('archive-s3-001')
+    })
+  })
+
+  describe('reorderArchives', () => {
+    it('should reorder archives and return the new order', async () => {
+      let receivedBody: Record<string, unknown> | undefined
+      server.use(
+        http.put(endpoints.updateLogsArchiveOrder, async ({ request }) => {
+          receivedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse(fixtures.order)
+        })
+      )
+
+      const result = await reorderArchives(api, [
+        'archive-s3-001',
+        'archive-gcs-001',
+        'archive-azure-001'
+      ])
+
+      expect(result.success).toBe(true)
+      expect((result.order as { archiveIds: string[] }).archiveIds).toEqual([
+        'archive-s3-001',
+        'archive-gcs-001',
+        'archive-azure-001'
+      ])
+
+      // SDK serializes camelCase archiveIds → wire archive_ids.
+      const data = receivedBody?.data as Record<string, unknown>
+      expect(data?.type).toBe('archive_order')
+      const attributes = data?.attributes as Record<string, unknown>
+      expect(attributes?.archive_ids).toEqual([
+        'archive-s3-001',
+        'archive-gcs-001',
+        'archive-azure-001'
+      ])
+    })
+  })
+
+  describe('getArchiveOrder', () => {
+    it('should return the current archive order', async () => {
+      server.use(
+        http.get(endpoints.getLogsArchiveOrder, () => {
+          return jsonResponse(fixtures.order)
+        })
+      )
+
+      const result = await getArchiveOrder(api)
+
+      expect((result.order as { archiveIds: string[] }).archiveIds).toEqual([
+        'archive-s3-001',
+        'archive-gcs-001',
+        'archive-azure-001'
+      ])
+    })
+  })
+
+  describe('registerLogsArchivesTool — read-only enforcement & dispatch', () => {
+    let mockServer: McpServer
+    let registeredHandler: (params: Record<string, unknown>) => Promise<unknown>
+
+    beforeEach(() => {
+      mockServer = {
+        tool: vi.fn(
+          (
+            _name: string,
+            _description: string,
+            _schema: unknown,
+            handler: (params: Record<string, unknown>) => Promise<unknown>
+          ) => {
+            registeredHandler = handler
+          }
+        )
+      } as unknown as McpServer
+    })
+
+    it('should register the tool with the expected name and description', () => {
+      registerLogsArchivesTool(mockServer, api, defaultLimits, false)
+
+      expect(mockServer.tool).toHaveBeenCalledWith(
+        'logs_archives',
+        expect.stringContaining('Datadog Logs archives'),
+        expect.any(Object),
+        expect.any(Function)
+      )
+    })
+
+    it('should require id for action=get and throw via requireParam', async () => {
+      registerLogsArchivesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'get' })).rejects.toThrow(/id/)
+    })
+
+    it('should require config for action=create and throw via requireParam', async () => {
+      registerLogsArchivesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'create' })).rejects.toThrow(/config/)
+    })
+
+    it('should require id for action=update and throw via requireParam', async () => {
+      registerLogsArchivesTool(mockServer, api, defaultLimits, false)
+
+      await expect(
+        registeredHandler({
+          action: 'update',
+          config: {
+            name: 'x',
+            query: '*',
+            destination: { type: 's3', bucket: 'b' }
+          }
+        })
+      ).rejects.toThrow(/id/)
+    })
+
+    it('should require config for action=update and throw via requireParam', async () => {
+      registerLogsArchivesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'update', id: 'archive-s3-001' })).rejects.toThrow(
+        /config/
+      )
+    })
+
+    it('should require id for action=delete and throw via requireParam', async () => {
+      registerLogsArchivesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'delete' })).rejects.toThrow(/id/)
+    })
+
+    it('should require archive_ids for action=reorder and throw via requireParam', async () => {
+      registerLogsArchivesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'reorder' })).rejects.toThrow(/archive_ids/)
+    })
+
+    it('should block action=create when readOnly=true', async () => {
+      registerLogsArchivesTool(mockServer, api, defaultLimits, true)
+
+      await expect(
+        registeredHandler({
+          action: 'create',
+          config: {
+            name: 'x',
+            query: '*',
+            destination: { type: 's3', bucket: 'b' }
+          }
+        })
+      ).rejects.toThrow(/read-only/)
+    })
+
+    it('should block action=update when readOnly=true', async () => {
+      registerLogsArchivesTool(mockServer, api, defaultLimits, true)
+
+      await expect(
+        registeredHandler({
+          action: 'update',
+          id: 'archive-s3-001',
+          config: {
+            name: 'x',
+            query: '*',
+            destination: { type: 's3', bucket: 'b' }
+          }
+        })
+      ).rejects.toThrow(/read-only/)
+    })
+
+    it('should block action=delete when readOnly=true', async () => {
+      registerLogsArchivesTool(mockServer, api, defaultLimits, true)
+
+      await expect(registeredHandler({ action: 'delete', id: 'archive-s3-001' })).rejects.toThrow(
+        /read-only/
+      )
+    })
+
+    it('should block action=reorder when readOnly=true', async () => {
+      registerLogsArchivesTool(mockServer, api, defaultLimits, true)
+
+      await expect(
+        registeredHandler({
+          action: 'reorder',
+          archive_ids: ['archive-s3-001', 'archive-gcs-001']
+        })
+      ).rejects.toThrow(/read-only/)
+    })
+
+    it('should allow read actions (list/get/get_order) when readOnly=true', async () => {
+      server.use(
+        http.get(endpoints.listLogsArchives, () => jsonResponse(fixtures.list)),
+        http.get(endpoints.getLogsArchive('archive-s3-001'), () => jsonResponse(fixtures.single)),
+        http.get(endpoints.getLogsArchiveOrder, () => jsonResponse(fixtures.order))
+      )
+
+      registerLogsArchivesTool(mockServer, api, defaultLimits, true)
+
+      await expect(registeredHandler({ action: 'list' })).resolves.toBeDefined()
+      await expect(
+        registeredHandler({ action: 'get', id: 'archive-s3-001' })
+      ).resolves.toBeDefined()
+      await expect(registeredHandler({ action: 'get_order' })).resolves.toBeDefined()
+    })
+  })
+})

--- a/tests/tools/logs_indexes.test.ts
+++ b/tests/tools/logs_indexes.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Unit tests for the logs_indexes tool.
+ *
+ * Covers each action's happy path, required-field validation on writes,
+ * snake_case normalization on update, 401/403/404/429 error propagation,
+ * read-only enforcement, schema rejection of create/delete (UI-only per Datadog),
+ * and verbose payload behavior.
+ *
+ * Requirements covered:
+ *   - Requirement 4  (list / get / verbose / error mapping)
+ *   - Requirement 5  (update only — create/delete must not appear in the enum)
+ *   - Requirement 6  (reorder / get_order / read-only)
+ *   - Requirement 10 (testing contract)
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { v1 } from '@datadog/datadog-api-client'
+import { z } from 'zod'
+import { http } from 'msw'
+import { server, endpoints, jsonResponse, errorResponse } from '../helpers/msw.js'
+import { createMockConfig } from '../helpers/mock.js'
+import { logsIndexesFixtures as fixtures } from '../helpers/fixtures.js'
+import {
+  listIndexes,
+  getIndex,
+  updateIndex,
+  reorderIndexes,
+  getIndexOrder,
+  registerLogsIndexesTool
+} from '../../src/tools/logs_indexes.js'
+import type { LimitsConfig } from '../../src/config/schema.js'
+
+const defaultLimits: LimitsConfig = {
+  maxResults: 100,
+  maxLogLines: 500,
+  maxMetricDataPoints: 1000,
+  defaultTimeRangeHours: 24
+}
+
+describe('Logs Indexes Tool', () => {
+  let api: v1.LogsIndexesApi
+
+  beforeEach(() => {
+    const config = createMockConfig()
+    api = new v1.LogsIndexesApi(config)
+  })
+
+  describe('listIndexes', () => {
+    it('should list indexes with default summary projection', async () => {
+      server.use(
+        http.get(endpoints.listLogsIndexes, () => {
+          return jsonResponse(fixtures.list)
+        })
+      )
+
+      const result = await listIndexes(api)
+
+      expect(result.indexes).toHaveLength(3)
+      expect(result.total).toBe(3)
+      const first = (result.indexes as Array<Record<string, unknown>>)[0]
+      expect(first.name).toBe('main')
+      expect(first.filterQuery).toBe('*')
+      expect(first.numRetentionDays).toBe(15)
+      expect(first.numFlexLogsRetentionDays).toBe(360)
+      expect(first.dailyLimit).toBe(1000000000)
+      expect(first.isRateLimited).toBe(false)
+      expect(first.exclusionFiltersCount).toBe(2)
+      // Default projection does NOT include the full exclusionFilters array.
+      expect(first.exclusionFilters).toBeUndefined()
+      // Raw payload only appears under verbose.
+      expect(result.raw).toBeUndefined()
+    })
+
+    it('should include the full SDK payload when verbose=true', async () => {
+      server.use(
+        http.get(endpoints.listLogsIndexes, () => {
+          return jsonResponse(fixtures.list)
+        })
+      )
+
+      const result = await listIndexes(api, true)
+
+      expect(result.indexes).toHaveLength(3)
+      // exclusionFilters array is retained in the summary under verbose.
+      const first = (result.indexes as Array<Record<string, unknown>>)[0]
+      expect(Array.isArray(first.exclusionFilters)).toBe(true)
+      expect((first.exclusionFilters as unknown[]).length).toBe(2)
+      // Raw payload is attached for callers that need fields outside the projection.
+      expect(result.raw).toBeDefined()
+    })
+
+    it('should propagate 401 unauthorized error on list', async () => {
+      server.use(
+        http.get(endpoints.listLogsIndexes, () => {
+          return errorResponse(401, 'Invalid API key')
+        })
+      )
+
+      await expect(listIndexes(api)).rejects.toMatchObject({ code: 401 })
+    })
+  })
+
+  describe('getIndex', () => {
+    it('should get a single index by name', async () => {
+      server.use(
+        http.get(endpoints.getLogsIndex('main'), () => {
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      const result = await getIndex(api, 'main')
+
+      const idx = result.index as Record<string, unknown>
+      expect(idx.name).toBe('main')
+      expect(idx.filterQuery).toBe('*')
+      expect(idx.numRetentionDays).toBe(15)
+      expect(idx.numFlexLogsRetentionDays).toBe(360)
+      expect(idx.exclusionFiltersCount).toBe(1)
+      expect(result.raw).toBeUndefined()
+    })
+
+    it('should include raw payload when verbose=true on get', async () => {
+      server.use(
+        http.get(endpoints.getLogsIndex('main'), () => {
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      const result = await getIndex(api, 'main', true)
+
+      expect(result.raw).toBeDefined()
+      const idx = result.index as Record<string, unknown>
+      expect(Array.isArray(idx.exclusionFilters)).toBe(true)
+    })
+
+    it('should propagate 404 not found error on get', async () => {
+      server.use(
+        http.get(endpoints.getLogsIndex('missing'), () => {
+          return errorResponse(404, 'Index not found')
+        })
+      )
+
+      await expect(getIndex(api, 'missing')).rejects.toMatchObject({ code: 404 })
+    })
+  })
+
+  describe('updateIndex', () => {
+    it('should update an index and normalize snake_case keys (num_retention_days → numRetentionDays)', async () => {
+      let receivedBody: Record<string, unknown> | undefined
+      server.use(
+        http.put(endpoints.updateLogsIndex('main'), async ({ request }) => {
+          receivedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse(fixtures.updated)
+        })
+      )
+
+      const result = await updateIndex(api, 'main', {
+        filter: { query: '*' },
+        num_retention_days: 30,
+        daily_limit: 2000000000,
+        exclusion_filters: [
+          {
+            name: 'Exclude debug logs',
+            is_enabled: true,
+            filter: {
+              query: 'status:debug',
+              sample_rate: 1.0
+            }
+          }
+        ]
+      })
+
+      expect(result.success).toBe(true)
+      const idx = result.index as Record<string, unknown>
+      expect(idx.name).toBe('main')
+      expect(idx.numRetentionDays).toBe(30)
+      expect(idx.dailyLimit).toBe(2000000000)
+      // Verify snake_case keys were normalized to camelCase BEFORE the SDK re-serialized
+      // them to snake_case on the wire (round-trip through the SDK model).
+      expect(receivedBody).toBeDefined()
+      expect(receivedBody?.num_retention_days).toBe(30)
+      expect(receivedBody?.daily_limit).toBe(2000000000)
+    })
+
+    it('should include raw payload when verbose=true on update', async () => {
+      server.use(
+        http.put(endpoints.updateLogsIndex('main'), () => {
+          return jsonResponse(fixtures.updated)
+        })
+      )
+
+      const result = await updateIndex(
+        api,
+        'main',
+        {
+          filter: { query: '*' },
+          num_retention_days: 30
+        },
+        true
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.raw).toBeDefined()
+    })
+
+    it('should throw when filter.query is missing on update', async () => {
+      await expect(
+        updateIndex(api, 'main', {
+          num_retention_days: 15
+        })
+      ).rejects.toThrow(/filter\.query/)
+    })
+
+    it('should throw when numRetentionDays is missing on update', async () => {
+      await expect(
+        updateIndex(api, 'main', {
+          filter: { query: '*' }
+        })
+      ).rejects.toThrow(/numRetentionDays/)
+    })
+
+    it('should propagate 403 forbidden error on update', async () => {
+      server.use(
+        http.put(endpoints.updateLogsIndex('main'), () => {
+          return errorResponse(403, 'Insufficient permissions')
+        })
+      )
+
+      await expect(
+        updateIndex(api, 'main', {
+          filter: { query: '*' },
+          num_retention_days: 15
+        })
+      ).rejects.toMatchObject({ code: 403 })
+    })
+  })
+
+  describe('reorderIndexes', () => {
+    it('should reorder indexes and return the new order', async () => {
+      let receivedBody: Record<string, unknown> | undefined
+      server.use(
+        http.put(endpoints.updateLogsIndexOrder, async ({ request }) => {
+          receivedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse(fixtures.order)
+        })
+      )
+
+      const result = await reorderIndexes(api, ['main', 'security', 'low-volume'])
+
+      expect(result.success).toBe(true)
+      expect((result.order as { indexNames: string[] }).indexNames).toEqual([
+        'main',
+        'security',
+        'low-volume'
+      ])
+      // SDK serializes camelCase indexNames → wire index_names.
+      expect(receivedBody?.index_names).toEqual(['main', 'security', 'low-volume'])
+    })
+
+    it('should propagate 429 rate limit error on reorder', async () => {
+      server.use(
+        http.put(endpoints.updateLogsIndexOrder, () => {
+          return errorResponse(429, 'Rate limit exceeded')
+        })
+      )
+
+      await expect(reorderIndexes(api, ['main', 'security'])).rejects.toMatchObject({ code: 429 })
+    })
+  })
+
+  describe('getIndexOrder', () => {
+    it('should return the current index order', async () => {
+      server.use(
+        http.get(endpoints.getLogsIndexOrder, () => {
+          return jsonResponse(fixtures.order)
+        })
+      )
+
+      const result = await getIndexOrder(api)
+
+      expect((result.order as { indexNames: string[] }).indexNames).toEqual([
+        'main',
+        'security',
+        'low-volume'
+      ])
+    })
+  })
+
+  describe('registerLogsIndexesTool — read-only enforcement, dispatch, and schema', () => {
+    let mockServer: McpServer
+    let registeredHandler: (params: Record<string, unknown>) => Promise<unknown>
+    let capturedSchema: Record<string, z.ZodTypeAny>
+
+    beforeEach(() => {
+      mockServer = {
+        tool: vi.fn(
+          (
+            _name: string,
+            _description: string,
+            schema: Record<string, z.ZodTypeAny>,
+            handler: (params: Record<string, unknown>) => Promise<unknown>
+          ) => {
+            capturedSchema = schema
+            registeredHandler = handler
+          }
+        )
+      } as unknown as McpServer
+    })
+
+    it('should register the tool with the expected name and description', () => {
+      registerLogsIndexesTool(mockServer, api, defaultLimits, false)
+
+      expect(mockServer.tool).toHaveBeenCalledWith(
+        'logs_indexes',
+        expect.stringContaining('Datadog Logs indexes'),
+        expect.any(Object),
+        expect.any(Function)
+      )
+    })
+
+    it('should expose a description stating that create/delete are UI-only per Datadog', () => {
+      registerLogsIndexesTool(mockServer, api, defaultLimits, false)
+
+      // Inspect the description that was registered.
+      const calls = (mockServer.tool as unknown as { mock: { calls: unknown[][] } }).mock.calls
+      const description = calls[0][1] as string
+      expect(description).toMatch(/UI-only/i)
+    })
+
+    it('should reject action=create at Zod parse time (UI-only per Datadog)', () => {
+      registerLogsIndexesTool(mockServer, api, defaultLimits, false)
+
+      const actionSchema = capturedSchema.action
+      const result = actionSchema.safeParse('create')
+      expect(result.success).toBe(false)
+    })
+
+    it('should reject action=delete at Zod parse time (UI-only per Datadog)', () => {
+      registerLogsIndexesTool(mockServer, api, defaultLimits, false)
+
+      const actionSchema = capturedSchema.action
+      const result = actionSchema.safeParse('delete')
+      expect(result.success).toBe(false)
+    })
+
+    it('should accept the documented actions (list, get, update, reorder, get_order)', () => {
+      registerLogsIndexesTool(mockServer, api, defaultLimits, false)
+
+      const actionSchema = capturedSchema.action
+      for (const action of ['list', 'get', 'update', 'reorder', 'get_order']) {
+        expect(actionSchema.safeParse(action).success).toBe(true)
+      }
+    })
+
+    it('should require name for action=get and throw EINVALID_PARAM via requireParam', async () => {
+      registerLogsIndexesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'get' })).rejects.toThrow(/name/)
+    })
+
+    it('should require name for action=update and throw EINVALID_PARAM via requireParam', async () => {
+      registerLogsIndexesTool(mockServer, api, defaultLimits, false)
+
+      await expect(
+        registeredHandler({ action: 'update', config: { filter: { query: '*' } } })
+      ).rejects.toThrow(/name/)
+    })
+
+    it('should require config for action=update and throw EINVALID_PARAM via requireParam', async () => {
+      registerLogsIndexesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'update', name: 'main' })).rejects.toThrow(/config/)
+    })
+
+    it('should require index_names for action=reorder and throw EINVALID_PARAM via requireParam', async () => {
+      registerLogsIndexesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'reorder' })).rejects.toThrow(/index_names/)
+    })
+
+    it('should block action=update when readOnly=true', async () => {
+      registerLogsIndexesTool(mockServer, api, defaultLimits, true)
+
+      await expect(
+        registeredHandler({
+          action: 'update',
+          name: 'main',
+          config: { filter: { query: '*' }, num_retention_days: 15 }
+        })
+      ).rejects.toThrow(/read-only/)
+    })
+
+    it('should block action=reorder when readOnly=true', async () => {
+      registerLogsIndexesTool(mockServer, api, defaultLimits, true)
+
+      await expect(
+        registeredHandler({ action: 'reorder', index_names: ['main', 'security'] })
+      ).rejects.toThrow(/read-only/)
+    })
+
+    it('should allow read actions (list/get/get_order) when readOnly=true', async () => {
+      server.use(
+        http.get(endpoints.listLogsIndexes, () => jsonResponse(fixtures.list)),
+        http.get(endpoints.getLogsIndex('main'), () => jsonResponse(fixtures.single)),
+        http.get(endpoints.getLogsIndexOrder, () => jsonResponse(fixtures.order))
+      )
+
+      registerLogsIndexesTool(mockServer, api, defaultLimits, true)
+
+      // These three should NOT throw under read-only mode.
+      await expect(registeredHandler({ action: 'list' })).resolves.toBeDefined()
+      await expect(registeredHandler({ action: 'get', name: 'main' })).resolves.toBeDefined()
+      await expect(registeredHandler({ action: 'get_order' })).resolves.toBeDefined()
+    })
+  })
+})

--- a/tests/tools/logs_pipelines.test.ts
+++ b/tests/tools/logs_pipelines.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Unit tests for the logs_pipelines tool.
+ *
+ * Covers each action's happy path, required-field validation on writes,
+ * snake_case normalization on update, 401/403/404/429 error propagation,
+ * read-only enforcement, and verbose payload behavior.
+ *
+ * Requirements covered:
+ *   - Requirement 1 (list / get / verbose / error mapping)
+ *   - Requirement 2 (create / update / delete / read-only / required params / pass-through)
+ *   - Requirement 3 (reorder / get_order / read-only)
+ *   - Requirement 10 (testing contract)
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { v1 } from '@datadog/datadog-api-client'
+import { http } from 'msw'
+import { server, endpoints, jsonResponse, errorResponse } from '../helpers/msw.js'
+import { createMockConfig } from '../helpers/mock.js'
+import { logsPipelinesFixtures as fixtures } from '../helpers/fixtures.js'
+import {
+  listPipelines,
+  getPipeline,
+  createPipeline,
+  updatePipeline,
+  deletePipeline,
+  reorderPipelines,
+  getPipelineOrder,
+  registerLogsPipelinesTool
+} from '../../src/tools/logs_pipelines.js'
+import type { LimitsConfig } from '../../src/config/schema.js'
+
+const defaultLimits: LimitsConfig = {
+  maxResults: 100,
+  maxLogLines: 500,
+  maxMetricDataPoints: 1000,
+  defaultTimeRangeHours: 24
+}
+
+describe('Logs Pipelines Tool', () => {
+  let api: v1.LogsPipelinesApi
+
+  beforeEach(() => {
+    const config = createMockConfig()
+    api = new v1.LogsPipelinesApi(config)
+  })
+
+  describe('listPipelines', () => {
+    it('should list pipelines with default summary projection', async () => {
+      server.use(
+        http.get(endpoints.listLogsPipelines, () => {
+          return jsonResponse(fixtures.list)
+        })
+      )
+
+      const result = await listPipelines(api)
+
+      expect(result.pipelines).toHaveLength(3)
+      expect(result.total).toBe(3)
+      const first = (result.pipelines as Array<Record<string, unknown>>)[0]
+      expect(first.id).toBe('pipeline-001')
+      expect(first.name).toBe('NGINX access logs')
+      expect(first.filterQuery).toBe('source:nginx')
+      expect(first.isEnabled).toBe(true)
+      expect(first.isReadOnly).toBe(false)
+      expect(first.type).toBe('pipeline')
+      expect(first.processorsCount).toBe(2)
+      // Default projection does NOT include the full processors array.
+      expect(first.processors).toBeUndefined()
+      // Raw payload only appears under verbose.
+      expect(result.raw).toBeUndefined()
+    })
+
+    it('should include the full SDK payload when verbose=true', async () => {
+      server.use(
+        http.get(endpoints.listLogsPipelines, () => {
+          return jsonResponse(fixtures.list)
+        })
+      )
+
+      const result = await listPipelines(api, true)
+
+      expect(result.pipelines).toHaveLength(3)
+      // Processors array is retained in the summary under verbose.
+      const first = (result.pipelines as Array<Record<string, unknown>>)[0]
+      expect(Array.isArray(first.processors)).toBe(true)
+      expect((first.processors as unknown[]).length).toBe(2)
+      // Raw payload is attached for callers that need fields outside the projection.
+      expect(result.raw).toBeDefined()
+      expect(Array.isArray(result.raw)).toBe(true)
+    })
+
+    it('should propagate 401 unauthorized error on list', async () => {
+      server.use(
+        http.get(endpoints.listLogsPipelines, () => {
+          return errorResponse(401, 'Invalid API key')
+        })
+      )
+
+      await expect(listPipelines(api)).rejects.toMatchObject({ code: 401 })
+    })
+  })
+
+  describe('getPipeline', () => {
+    it('should get a single pipeline by ID', async () => {
+      server.use(
+        http.get(endpoints.getLogsPipeline('pipeline-001'), () => {
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      const result = await getPipeline(api, 'pipeline-001')
+
+      expect((result.pipeline as Record<string, unknown>).id).toBe('pipeline-001')
+      expect((result.pipeline as Record<string, unknown>).name).toBe('NGINX access logs')
+      expect((result.pipeline as Record<string, unknown>).filterQuery).toBe('source:nginx')
+      expect((result.pipeline as Record<string, unknown>).processorsCount).toBe(1)
+    })
+
+    it('should propagate 404 not found error on get', async () => {
+      server.use(
+        http.get(endpoints.getLogsPipeline('missing'), () => {
+          return errorResponse(404, 'Pipeline not found')
+        })
+      )
+
+      await expect(getPipeline(api, 'missing')).rejects.toMatchObject({ code: 404 })
+    })
+  })
+
+  describe('createPipeline', () => {
+    it('should create a new pipeline with snake_case input normalized', async () => {
+      let receivedBody: Record<string, unknown> | undefined
+      server.use(
+        http.post(endpoints.createLogsPipeline, async ({ request }) => {
+          receivedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse(fixtures.created)
+        })
+      )
+
+      const result = await createPipeline(api, {
+        name: 'New Pipeline',
+        filter: { query: 'service:new-service' },
+        is_enabled: true,
+        processors: []
+      })
+
+      expect(result.success).toBe(true)
+      expect((result.pipeline as Record<string, unknown>).id).toBe('pipeline-new-001')
+      // SDK serializes camelCase model back to snake_case on the wire.
+      expect(receivedBody).toBeDefined()
+      expect(receivedBody?.name).toBe('New Pipeline')
+      expect(receivedBody?.is_enabled).toBe(true)
+    })
+
+    it('should throw EINVALID_PARAM when name is missing on create', async () => {
+      await expect(
+        createPipeline(api, {
+          filter: { query: 'service:foo' }
+        })
+      ).rejects.toThrow(/name/)
+    })
+
+    it('should throw EINVALID_PARAM when filter.query is missing on create', async () => {
+      await expect(
+        createPipeline(api, {
+          name: 'No filter pipeline'
+        })
+      ).rejects.toThrow(/filter\.query/)
+    })
+
+    it('should propagate 429 rate limit error on create', async () => {
+      server.use(
+        http.post(endpoints.createLogsPipeline, () => {
+          return errorResponse(429, 'Rate limit exceeded')
+        })
+      )
+
+      await expect(
+        createPipeline(api, {
+          name: 'Rate-limited Pipeline',
+          filter: { query: 'service:foo' }
+        })
+      ).rejects.toMatchObject({ code: 429 })
+    })
+  })
+
+  describe('updatePipeline', () => {
+    it('should update a pipeline and normalize snake_case keys (filter_query → filterQuery)', async () => {
+      let receivedBody: Record<string, unknown> | undefined
+      server.use(
+        http.put(endpoints.updateLogsPipeline('pipeline-001'), async ({ request }) => {
+          receivedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse(fixtures.updated)
+        })
+      )
+
+      const result = await updatePipeline(api, 'pipeline-001', {
+        name: 'NGINX access logs (updated)',
+        filter: { query: 'source:nginx AND env:production' },
+        is_enabled: false,
+        is_read_only: false
+      })
+
+      expect(result.success).toBe(true)
+      expect((result.pipeline as Record<string, unknown>).id).toBe('pipeline-001')
+      expect((result.pipeline as Record<string, unknown>).filterQuery).toBe(
+        'source:nginx AND env:production'
+      )
+      // Verify snake_case was normalized inside the tool before the SDK serialized it.
+      expect(receivedBody).toBeDefined()
+      expect(receivedBody?.is_enabled).toBe(false)
+    })
+
+    it('should propagate 403 forbidden error on update', async () => {
+      server.use(
+        http.put(endpoints.updateLogsPipeline('pipeline-001'), () => {
+          return errorResponse(403, 'Insufficient permissions')
+        })
+      )
+
+      await expect(
+        updatePipeline(api, 'pipeline-001', {
+          name: 'Updated',
+          filter: { query: 'source:nginx' }
+        })
+      ).rejects.toMatchObject({ code: 403 })
+    })
+  })
+
+  describe('deletePipeline', () => {
+    it('should delete a pipeline', async () => {
+      server.use(
+        http.delete(endpoints.deleteLogsPipeline('pipeline-001'), () => {
+          return new Response(null, { status: 204 })
+        })
+      )
+
+      const result = await deletePipeline(api, 'pipeline-001')
+
+      expect(result.success).toBe(true)
+      expect(result.message).toContain('pipeline-001')
+    })
+  })
+
+  describe('reorderPipelines', () => {
+    it('should reorder pipelines and return the new order', async () => {
+      let receivedBody: Record<string, unknown> | undefined
+      server.use(
+        http.put(endpoints.updateLogsPipelineOrder, async ({ request }) => {
+          receivedBody = (await request.json()) as Record<string, unknown>
+          return jsonResponse(fixtures.order)
+        })
+      )
+
+      const result = await reorderPipelines(api, ['pipeline-003', 'pipeline-001', 'pipeline-002'])
+
+      expect(result.success).toBe(true)
+      expect((result.order as { pipelineIds: string[] }).pipelineIds).toEqual([
+        'pipeline-003',
+        'pipeline-001',
+        'pipeline-002'
+      ])
+      // SDK serializes camelCase pipelineIds → wire pipeline_ids.
+      expect(receivedBody?.pipeline_ids).toEqual(['pipeline-003', 'pipeline-001', 'pipeline-002'])
+    })
+  })
+
+  describe('getPipelineOrder', () => {
+    it('should return the current pipeline order', async () => {
+      server.use(
+        http.get(endpoints.getLogsPipelineOrder, () => {
+          return jsonResponse(fixtures.order)
+        })
+      )
+
+      const result = await getPipelineOrder(api)
+
+      expect((result.order as { pipelineIds: string[] }).pipelineIds).toEqual([
+        'pipeline-003',
+        'pipeline-001',
+        'pipeline-002'
+      ])
+    })
+  })
+
+  describe('registerLogsPipelinesTool — read-only enforcement & dispatch', () => {
+    let mockServer: McpServer
+    let registeredHandler: (params: Record<string, unknown>) => Promise<unknown>
+
+    beforeEach(() => {
+      mockServer = {
+        tool: vi.fn(
+          (
+            _name: string,
+            _description: string,
+            _schema: unknown,
+            handler: (params: Record<string, unknown>) => Promise<unknown>
+          ) => {
+            registeredHandler = handler
+          }
+        )
+      } as unknown as McpServer
+    })
+
+    it('should register the tool with the expected name and description', () => {
+      registerLogsPipelinesTool(mockServer, api, defaultLimits, false)
+
+      expect(mockServer.tool).toHaveBeenCalledWith(
+        'logs_pipelines',
+        expect.stringContaining('Datadog Logs pipelines'),
+        expect.any(Object),
+        expect.any(Function)
+      )
+    })
+
+    it('should require id for action=get and throw EINVALID_PARAM via requireParam', async () => {
+      registerLogsPipelinesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'get' })).rejects.toThrow(/id/)
+    })
+
+    it('should require config for action=create and throw EINVALID_PARAM via requireParam', async () => {
+      registerLogsPipelinesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'create' })).rejects.toThrow(/config/)
+    })
+
+    it('should require id for action=update and throw EINVALID_PARAM via requireParam', async () => {
+      registerLogsPipelinesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'update', config: { name: 'x' } })).rejects.toThrow(
+        /id/
+      )
+    })
+
+    it('should require id for action=delete and throw EINVALID_PARAM via requireParam', async () => {
+      registerLogsPipelinesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'delete' })).rejects.toThrow(/id/)
+    })
+
+    it('should require pipeline_ids for action=reorder and throw EINVALID_PARAM via requireParam', async () => {
+      registerLogsPipelinesTool(mockServer, api, defaultLimits, false)
+
+      await expect(registeredHandler({ action: 'reorder' })).rejects.toThrow(/pipeline_ids/)
+    })
+
+    it('should block action=create when readOnly=true', async () => {
+      registerLogsPipelinesTool(mockServer, api, defaultLimits, true)
+
+      await expect(
+        registeredHandler({
+          action: 'create',
+          config: { name: 'x', filter: { query: '*' } }
+        })
+      ).rejects.toThrow(/read-only/)
+    })
+
+    it('should block action=update when readOnly=true', async () => {
+      registerLogsPipelinesTool(mockServer, api, defaultLimits, true)
+
+      await expect(
+        registeredHandler({
+          action: 'update',
+          id: 'pipeline-001',
+          config: { name: 'x', filter: { query: '*' } }
+        })
+      ).rejects.toThrow(/read-only/)
+    })
+
+    it('should block action=delete when readOnly=true', async () => {
+      registerLogsPipelinesTool(mockServer, api, defaultLimits, true)
+
+      await expect(registeredHandler({ action: 'delete', id: 'pipeline-001' })).rejects.toThrow(
+        /read-only/
+      )
+    })
+
+    it('should block action=reorder when readOnly=true', async () => {
+      registerLogsPipelinesTool(mockServer, api, defaultLimits, true)
+
+      await expect(
+        registeredHandler({ action: 'reorder', pipeline_ids: ['a', 'b'] })
+      ).rejects.toThrow(/read-only/)
+    })
+
+    it('should allow read actions (list/get/get_order) when readOnly=true', async () => {
+      server.use(
+        http.get(endpoints.listLogsPipelines, () => jsonResponse(fixtures.list)),
+        http.get(endpoints.getLogsPipeline('pipeline-001'), () => jsonResponse(fixtures.single)),
+        http.get(endpoints.getLogsPipelineOrder, () => jsonResponse(fixtures.order))
+      )
+
+      registerLogsPipelinesTool(mockServer, api, defaultLimits, true)
+
+      // These three should NOT throw under read-only mode.
+      await expect(registeredHandler({ action: 'list' })).resolves.toBeDefined()
+      await expect(registeredHandler({ action: 'get', id: 'pipeline-001' })).resolves.toBeDefined()
+      await expect(registeredHandler({ action: 'get_order' })).resolves.toBeDefined()
+    })
+  })
+})

--- a/tests/tools/logs_pipelines.test.ts
+++ b/tests/tools/logs_pipelines.test.ts
@@ -226,6 +226,24 @@ describe('Logs Pipelines Tool', () => {
         })
       ).rejects.toMatchObject({ code: 403 })
     })
+
+    it('should throw when name is missing on update (PUT is full-replacement)', async () => {
+      // Datadog's PUT replaces the full resource — omitting name must fail at
+      // the input surface, not produce a cryptic API error downstream.
+      await expect(
+        updatePipeline(api, 'pipeline-001', {
+          filter: { query: 'source:nginx' }
+        })
+      ).rejects.toThrow(/name/)
+    })
+
+    it('should throw when filter.query is missing on update (PUT is full-replacement)', async () => {
+      await expect(
+        updatePipeline(api, 'pipeline-001', {
+          name: 'Missing filter'
+        })
+      ).rejects.toThrow(/filter\.query/)
+    })
   })
 
   describe('deletePipeline', () => {

--- a/tests/utils/normalize.test.ts
+++ b/tests/utils/normalize.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Unit tests for the shared normalize utilities (snakeToCamel, normalizeConfigKeys)
+ *
+ * These helpers are consumed by multiple tools (slos, logs_pipelines, logs_indexes,
+ * logs_archives) to normalize MCP caller payloads that arrive in snake_case before
+ * forwarding them to the Datadog SDK, which expects camelCase keys.
+ */
+import { describe, it, expect } from 'vitest'
+import { snakeToCamel, normalizeConfigKeys } from '../../src/utils/normalize.js'
+
+describe('snakeToCamel', () => {
+  it('converts simple snake_case to camelCase', () => {
+    expect(snakeToCamel('target_threshold')).toBe('targetThreshold')
+    expect(snakeToCamel('time_window')).toBe('timeWindow')
+    expect(snakeToCamel('error_budget')).toBe('errorBudget')
+  })
+
+  it('handles multiple underscores', () => {
+    expect(snakeToCamel('monitor_search_query')).toBe('monitorSearchQuery')
+    expect(snakeToCamel('num_retention_days')).toBe('numRetentionDays')
+  })
+
+  it('preserves already-camelCase strings', () => {
+    expect(snakeToCamel('targetThreshold')).toBe('targetThreshold')
+    expect(snakeToCamel('numRetentionDays')).toBe('numRetentionDays')
+  })
+
+  it('preserves single words with no underscores', () => {
+    expect(snakeToCamel('name')).toBe('name')
+    expect(snakeToCamel('query')).toBe('query')
+  })
+
+  it('handles short keys with a single underscore', () => {
+    expect(snakeToCamel('api_key')).toBe('apiKey')
+    expect(snakeToCamel('a_b')).toBe('aB')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(snakeToCamel('')).toBe('')
+  })
+})
+
+describe('normalizeConfigKeys', () => {
+  it('returns null unchanged', () => {
+    expect(normalizeConfigKeys(null)).toBeNull()
+  })
+
+  it('returns undefined unchanged', () => {
+    expect(normalizeConfigKeys(undefined)).toBeUndefined()
+  })
+
+  it('returns primitive strings unchanged', () => {
+    expect(normalizeConfigKeys('hello_world')).toBe('hello_world')
+  })
+
+  it('returns primitive numbers unchanged', () => {
+    expect(normalizeConfigKeys(42)).toBe(42)
+    expect(normalizeConfigKeys(3.14)).toBe(3.14)
+  })
+
+  it('returns primitive booleans unchanged', () => {
+    expect(normalizeConfigKeys(true)).toBe(true)
+    expect(normalizeConfigKeys(false)).toBe(false)
+  })
+
+  it('converts top-level snake_case keys to camelCase', () => {
+    const input = { filter_query: 'service:api', num_retention_days: 15 }
+    expect(normalizeConfigKeys(input)).toEqual({
+      filterQuery: 'service:api',
+      numRetentionDays: 15
+    })
+  })
+
+  it('recursively converts nested object keys', () => {
+    const input = {
+      outer_key: {
+        inner_key: {
+          deep_key: 'value'
+        }
+      }
+    }
+    expect(normalizeConfigKeys(input)).toEqual({
+      outerKey: {
+        innerKey: {
+          deepKey: 'value'
+        }
+      }
+    })
+  })
+
+  it('converts keys inside arrays of objects', () => {
+    const input = {
+      thresholds: [
+        { target_threshold: 99.9, time_window: '7d' },
+        { target_threshold: 99.5, time_window: '30d' }
+      ]
+    }
+    expect(normalizeConfigKeys(input)).toEqual({
+      thresholds: [
+        { targetThreshold: 99.9, timeWindow: '7d' },
+        { targetThreshold: 99.5, timeWindow: '30d' }
+      ]
+    })
+  })
+
+  it('preserves arrays of primitives unchanged', () => {
+    const input = { tags: ['env:prod', 'team:platform'] }
+    expect(normalizeConfigKeys(input)).toEqual({ tags: ['env:prod', 'team:platform'] })
+  })
+
+  it('preserves arrays containing null entries', () => {
+    expect(normalizeConfigKeys([null, 1, 'x', null])).toEqual([null, 1, 'x', null])
+  })
+
+  it('passes through null and undefined values inside objects without crashing', () => {
+    const input = { my_field: null, other_field: undefined, kept_field: 'value' }
+    expect(normalizeConfigKeys(input)).toEqual({
+      myField: null,
+      otherField: undefined,
+      keptField: 'value'
+    })
+  })
+
+  it('returns a new object — does not mutate input', () => {
+    const input = { foo_bar: 1, nested: { baz_qux: 2 } }
+    const result = normalizeConfigKeys(input) as Record<string, unknown>
+
+    expect(result).not.toBe(input)
+    expect((result.nested as Record<string, unknown>) === input.nested).toBe(false)
+    // Input retains its original keys
+    expect(input).toEqual({ foo_bar: 1, nested: { baz_qux: 2 } })
+  })
+
+  it('handles mixed snake and camel keys side by side', () => {
+    const input = { snake_case_key: 1, camelCaseKey: 2 }
+    expect(normalizeConfigKeys(input)).toEqual({ snakeCaseKey: 1, camelCaseKey: 2 })
+  })
+
+  it('preserves Datadog archive destination structure on round-trip', () => {
+    const input = {
+      name: 'prod-archive',
+      query: 'service:api',
+      destination: {
+        type: 's3',
+        bucket: 'my-bucket',
+        path: 'logs/',
+        integration: { role_name: 'datadog-role', account_id: '123' }
+      },
+      include_tags: true,
+      rehydration_tags: ['env:prod']
+    }
+    expect(normalizeConfigKeys(input)).toEqual({
+      name: 'prod-archive',
+      query: 'service:api',
+      destination: {
+        type: 's3',
+        bucket: 'my-bucket',
+        path: 'logs/',
+        integration: { roleName: 'datadog-role', accountId: '123' }
+      },
+      includeTags: true,
+      rehydrationTags: ['env:prod']
+    })
+  })
+})


### PR DESCRIPTION
Implements `logs-config-tools` spec — addresses #50.

## Summary

Three new MCP tools wrapping Datadog's log management configuration APIs:

- **`logs_pipelines`** (v1 LogsPipelinesApi) — list/get/create/update/delete/reorder/get_order.
- **`logs_indexes`** (v1 LogsIndexesApi) — list/get/update/reorder/get_order. `create` and `delete` are deliberately omitted (UI-only per Datadog) and the ActionSchema rejects them.
- **`logs_archives`** (v2 LogsArchivesApi) — list/get/create/update/delete/reorder/get_order, with destination discriminator validation (`s3`/`gcs`/`azure_storage`).

Each tool follows the established action-dispatched pattern from `monitors.ts` and `slos.ts`: zod input schema, `formatX` projection, `verbose: true` for full SDK payload, snake_case→camelCase normalization, `requireParam`/`checkReadOnly` gating, errors routed through `handleDatadogError`.

## Supporting changes

- `src/utils/normalize.ts` (new) — extracted `snakeToCamel` and `normalizeConfigKeys` from `slos.ts` into a shared utility. `slos.ts` re-exports them for backward compatibility.
- `src/config/datadog.ts` — added `logsPipelines`, `logsIndexes`, `logsArchives` to `DatadogClients`.
- `src/tools/index.ts` — wired the three new tools into `registerAllTools` with the standard `enabled()` helper so they respect `disabledTools`.
- `src/errors/datadog.ts` — added `'reorder'` to `WRITE_ACTIONS` so read-only mode blocks reorder actions (was a no-op before).

## Tests

- 25 tests for `logs_pipelines`
- 26 tests for `logs_indexes` (including ActionSchema rejection of `create`/`delete`)
- 32 tests for `logs_archives` (including destination discriminator + round-trip)
- 20 tests for `normalize` utility (nested objects, arrays, primitives, null/undefined)
- Updated `tests/tools/index.test.ts` (8 tests) — covers new tool registration + per-tool disable
- Updated `tests/config/datadog.test.ts` mock to include new APIs
- Full suite: **1115/1115 pass** across 67 files (was 1081 — net +34)

## Notable findings

1. **Azure discriminator mismatch**: spec accepts `destination.type: 'azure_storage'` but the SDK literal is `"azure"`. The tool validates against the spec value; wire-level behavior may need adjustment in a follow-up if Datadog rejects.
2. **v2 S3 destination has no `region` field**: the SDK's `LogsArchiveDestinationS3` omits region (Datadog derives from IAM role). Round-trip tests verify pass-through only for fields the SDK retains.
3. **`reorder` was not in `WRITE_ACTIONS`**: pre-existing gap surfaced during Task 3; fixed in this PR so all three new tools' read-only gating actually works.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test -- --run` (1115/1115)
- [x] `npm run build`