### PR TITLE
feat(monitors): action=history for real state transition counts (#53)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ When running with `--transport=http`:
 | `monitors` | delete | Alerting | Delete a monitor | `monitors_write` |
 | `monitors` | mute | Alerting | Mute a monitor | `monitors_write` |
 | `monitors` | unmute | Alerting | Unmute a monitor | `monitors_write` |
-| `monitors` | top | Alerting | Top N monitors by alert frequency with real monitor names and context breakdown. Groups without context tags are included as "no_context" | `monitors_read` |
+| `monitors` | top | Alerting | Top N monitors by alert frequency with real monitor names and context breakdown. **WARNING:** `total_count` includes renotifies/re-evaluations (Datadog emits a renotify event every `renotify_interval` minutes while Alert). For real fires use `action=history`. | `monitors_read` |
+| `monitors` | history | Alerting | Count and list real state transitions for one monitor over a time window. Filters by `transitionType` (default `["alert","alert recovery"]` — fires+recoveries, excludes renotifies) and optional `group`. Returns `{transitions: [...], count, meta}` where `count` is the number of real transitions (e.g. for one always-Alert burn-rate monitor over 7d: 98 raw events vs **38 real transitions**). | `monitors_read`, `events_read` |
 | `dashboards` | list | Visualization | List all dashboards | `dashboards_read` |
 | `dashboards` | get | Visualization | Get dashboard by ID | `dashboards_read` |
 | `dashboards` | create | Visualization | Create a new dashboard | `dashboards_write` |
@@ -154,7 +155,7 @@ When running with `--transport=http`:
 | `events` | list | Events | List events | `events_read` |
 | `events` | get | Events | Get event by ID | `events_read` |
 | `events` | create | Events | Create an event | `events_read` |
-| `events` | search | Events | Search events with v2 API and cursor pagination | `events_read` |
+| `events` | search | Events | Search events with v2 API and cursor pagination. Optional `transitionType` filter (e.g. `["alert","alert recovery"]`) restricts to monitor state-transition events — without it, `source:alert` includes renotifies. For monitor-specific fires use `monitors action=history`. | `events_read` |
 | `events` | aggregate | Events | Client-side aggregation by monitor_name, source, etc. | `events_read` |
 | `events` | top | Events | Top N event groups by count with generic groupBy support (deployments, configs, alerts, etc.). Groups without context tags are included as "no_context" | `events_read` |
 | `events` | timeseries | Events | Time-bucketed alert trends (hourly/daily counts) | `events_read` |

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -74,6 +74,23 @@ const InputSchema = {
     .optional()
     .describe(
       'Maximum events to fetch for grouping in top action (default: 5000, max: 5000). Higher = more accurate but slower'
+    ),
+  // Monitor transition filter (additive — see requirement 5.2 / monitors action=history)
+  transitionType: z
+    .array(
+      z.enum([
+        'alert',
+        'alert recovery',
+        'warning',
+        'warning recovery',
+        'no data',
+        'no data recovery',
+        'renotify'
+      ])
+    )
+    .optional()
+    .describe(
+      'Filter events by monitor state transition type. When set, restricts results to events with @monitor.transition.transition_type matching any value. Use ["alert","alert recovery"] to count real fires/recoveries and skip renotifies. Empty array is treated as undefined (no filter). For a fires-only count by monitor ID, prefer monitors action=history.'
     )
 }
 
@@ -517,13 +534,30 @@ export async function createEventV1(
 // ============ V2 API Functions (new capabilities) ============
 
 /**
- * Build a Datadog event search query from filter parameters
+ * Quote a value for inclusion in a Datadog event search query.
+ * Values containing whitespace or characters outside a small safe set are
+ * wrapped in double quotes; safe single-word values stay unquoted. Mirrors the
+ * helper used by `buildMonitorHistoryQuery` in `monitors.ts`.
+ */
+function quoteIfNeeded(value: string): string {
+  return /^[A-Za-z0-9_.-]+$/.test(value) ? value : `"${value}"`
+}
+
+/**
+ * Build a Datadog event search query from filter parameters.
+ *
+ * `transitionType` is additive: when omitted or an empty array, the emitted
+ * query string is byte-identical to the pre-spec behaviour (requirement 5.1).
+ * When non-empty, appends `@monitor.transition.transition_type:(a OR "b c" OR ...)`
+ * with multi-word values quoted, matching the live investigation in
+ * design.md ("API Investigation Result").
  */
 export function buildEventQuery(params: {
   query?: string
   sources?: string[]
   tags?: string[]
   priority?: string
+  transitionType?: string[]
 }): string {
   const parts: string[] = []
 
@@ -546,6 +580,11 @@ export function buildEventQuery(params: {
     parts.push(`priority:${params.priority}`)
   }
 
+  if (params.transitionType && params.transitionType.length > 0) {
+    const inner = params.transitionType.map(quoteIfNeeded).join(' OR ')
+    parts.push(`@monitor.transition.transition_type:(${inner})`)
+  }
+
   return parts.length > 0 ? parts.join(' ') : '*'
 }
 
@@ -560,6 +599,7 @@ export async function searchEventsV2(
     priority?: string
     limit?: number
     cursor?: string
+    transitionType?: string[]
   },
   limits: LimitsConfig,
   site: string
@@ -578,7 +618,8 @@ export async function searchEventsV2(
     query: params.query,
     sources: params.sources,
     tags: params.tags,
-    priority: params.priority
+    priority: params.priority,
+    transitionType: params.transitionType
   })
 
   const effectiveLimit = params.limit ?? limits.defaultLimit
@@ -628,6 +669,7 @@ export async function aggregateEventsV2(
     tags?: string[]
     groupBy?: string[]
     limit?: number
+    transitionType?: string[]
   },
   limits: LimitsConfig,
   site: string
@@ -647,7 +689,8 @@ export async function aggregateEventsV2(
   const fullQuery = buildEventQuery({
     query: params.query,
     sources: params.sources,
-    tags: params.tags
+    tags: params.tags,
+    transitionType: params.transitionType
   })
 
   const groupByFields = params.groupBy ?? ['monitor_name']
@@ -745,6 +788,7 @@ export async function topEventsV2(
     groupBy?: string[]
     contextTags?: string[]
     maxEvents?: number
+    transitionType?: string[]
   },
   limits: LimitsConfig,
   site: string
@@ -780,7 +824,8 @@ export async function topEventsV2(
       to: params.to,
       sources: params.sources,
       tags: effectiveTags,
-      limit: params.maxEvents ?? 5000
+      limit: params.maxEvents ?? 5000,
+      transitionType: params.transitionType
     },
     limits,
     site
@@ -915,6 +960,7 @@ export async function timeseriesEventsV2(
     groupBy?: string[]
     interval?: string
     limit?: number
+    transitionType?: string[]
   },
   limits: LimitsConfig,
   site: string
@@ -932,7 +978,8 @@ export async function timeseriesEventsV2(
   const fullQuery = buildEventQuery({
     query: params.query ?? 'source:alert',
     sources: params.sources,
-    tags: params.tags
+    tags: params.tags,
+    transitionType: params.transitionType
   })
 
   const intervalMs = parseIntervalToMs(params.interval)
@@ -1043,6 +1090,7 @@ export async function incidentsEventsV2(
     tags?: string[]
     dedupeWindow?: string
     limit?: number
+    transitionType?: string[]
   },
   limits: LimitsConfig,
   site: string
@@ -1060,7 +1108,8 @@ export async function incidentsEventsV2(
   const fullQuery = buildEventQuery({
     query: params.query ?? 'source:alert',
     sources: params.sources,
-    tags: params.tags
+    tags: params.tags,
+    transitionType: params.transitionType
   })
 
   // Parse dedupe window (default 5 minutes)
@@ -1333,10 +1382,17 @@ export function registerEventsTool(
     `Track Datadog events. Actions: list, get, create, search, aggregate, top, timeseries, incidents, discover.
 For monitor alerts, use tags: ["source:alert"].
 
+IMPORTANT — re-evaluation vs transition:
+  - source:alert events INCLUDE renotifies and re-evaluations (every Datadog re-evaluation of an alerting monitor emits an event). A "how many times did monitor X fire" question answered with source:alert alone over-counts.
+  - To restrict to real state transitions, pass transitionType (e.g. ["alert","alert recovery"]). This appends @monitor.transition.transition_type:(...) to the query and matches the design's live investigation.
+  - For a fires-only numeric count rooted in a single monitor ID, prefer the higher-level primitive monitors action=history — it returns {transitions, count, meta} with the same filter applied for you.
+
+transitionType: Optional array of monitor transition types (alert, alert recovery, warning, warning recovery, no data, no data recovery, renotify). Empty array is treated as undefined.
 top: Generic event grouping by any fields (groupBy parameter). Returns groups ranked by count with optional context breakdown.
   - Example: {groupBy: ["service"], message: "...", service: "api", total_count: 50, by_context: [{context: "queue:X", count: 30}]}
   - Use for deployments, configs, custom events, or monitor alerts
   - Returns "message" field (event title), NOT monitor name (use monitors tool for real names)
+  - total_count includes renotifies when source:alert is used without transitionType — see monitors action=history for fires-only counts
 discover: Returns available tag prefixes from events.
 aggregate: Custom groupBy, returns pipe-delimited keys.
 search: Full event details.
@@ -1362,7 +1418,8 @@ incidents: Deduplicate alerts with dedupeWindow.`,
       dedupeWindow,
       enrich,
       contextTags,
-      maxEvents
+      maxEvents,
+      transitionType
     }) => {
       try {
         checkReadOnly(action, readOnly)
@@ -1414,7 +1471,8 @@ incidents: Deduplicate alerts with dedupeWindow.`,
                 tags,
                 priority,
                 limit,
-                cursor
+                cursor,
+                transitionType
               },
               limits,
               site
@@ -1440,7 +1498,8 @@ incidents: Deduplicate alerts with dedupeWindow.`,
                   sources,
                   tags,
                   groupBy,
-                  limit
+                  limit,
+                  transitionType
                 },
                 limits,
                 site
@@ -1460,7 +1519,8 @@ incidents: Deduplicate alerts with dedupeWindow.`,
                   limit,
                   groupBy,
                   contextTags,
-                  maxEvents
+                  maxEvents,
+                  transitionType
                 },
                 limits,
                 site
@@ -1495,7 +1555,8 @@ incidents: Deduplicate alerts with dedupeWindow.`,
                   tags,
                   groupBy,
                   interval,
-                  limit
+                  limit,
+                  transitionType
                 },
                 limits,
                 site
@@ -1513,7 +1574,8 @@ incidents: Deduplicate alerts with dedupeWindow.`,
                   sources,
                   tags,
                   dedupeWindow,
-                  limit
+                  limit,
+                  transitionType
                 },
                 limits,
                 site

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -18,7 +18,8 @@ const ActionSchema = z.enum([
   'delete',
   'mute',
   'unmute',
-  'top'
+  'top',
+  'history'
 ])
 
 const InputSchema = {
@@ -58,7 +59,30 @@ const InputSchema = {
     .min(1)
     .max(5000)
     .optional()
-    .describe('Maximum events to fetch for top action (default: 5000, max: 5000)')
+    .describe('Maximum events to fetch for top action (default: 5000, max: 5000)'),
+  // History action parameters
+  transitionType: z
+    .array(
+      z.enum([
+        'alert',
+        'alert recovery',
+        'warning',
+        'warning recovery',
+        'no data',
+        'no data recovery',
+        'renotify'
+      ])
+    )
+    .optional()
+    .describe(
+      'For history action: filter by monitor state transition types. Default: ["alert","alert recovery"] (real fires + recoveries, excludes renotifies). Pass ["alert"] for fires only, or include "renotify" for full chronological audit.'
+    ),
+  group: z
+    .string()
+    .optional()
+    .describe(
+      'For history action: filter transitions to a specific multi-alert monitor group (e.g., "pod_name:foo,kube_namespace:bar"). Optional; omit for all groups.'
+    )
 }
 
 // Nested schemas for MonitorOptionsSchema (see design.md Data model).
@@ -1078,7 +1102,7 @@ export function registerMonitorsTool(
 ): void {
   server.tool(
     'monitors',
-    `Manage Datadog monitors. Actions: list, get, search, create, update, delete, mute, unmute, top.
+    `Manage Datadog monitors. Actions: list, get, search, create, update, delete, mute, unmute, top, history.
 Filters: name, tags, groupStates (alert/warn/ok/no data).
 get/create/update return the full options object so callers can safely read-then-patch.
 
@@ -1100,8 +1124,25 @@ top: Ranked monitors by alert frequency with real monitor names and context brea
   - Returns: {rank, monitor_id, name (with {{template.vars}}), message (template), total_count, by_context}
   - Perfect for weekly/daily alert reports
   - Gets real monitor names from monitors API (not event titles)
+  - WARNING: total_count is the raw alert-event count and INCLUDES renotifies/re-evaluations.
+    For monitors stuck in Alert state, Datadog emits a renotify event every renotify_interval
+    minutes, which inflates this count well beyond the number of real fires. When the question
+    is "how many times did this monitor actually fire", use action=history instead.
 
-For generic event grouping (deployments, configs), use events tool instead.`,
+history: Count and list real state transitions for one monitor over a time window.
+  - Inputs: id (required, monitor ID), from/to (optional time range), transitionType (optional
+    filter, defaults to ["alert","alert recovery"]), group (optional multi-alert group filter).
+  - Returns: {transitions: [{timestamp, monitorId, monitorName, group, fromState, toState,
+    transitionType, eventId}], count, meta}
+  - count = transitions.length — the number of REAL state changes (fires + recoveries by
+    default), NOT the renotify-inflated count returned by action=top or events action=search.
+  - Backed by Datadog v2 events search with a hardcoded source:alert + @monitor.transition.
+    transition_type filter that excludes renotifies by default. To include renotifies, pass
+    transitionType including "renotify".
+
+For generic event grouping (deployments, configs), use events tool instead. Note that the
+events tool's action=search with source:alert ALSO includes renotifies; use its
+transitionType filter (or this action=history) for fires-only counts.`,
     InputSchema,
     async ({
       action,
@@ -1116,7 +1157,9 @@ For generic event grouping (deployments, configs), use events tool instead.`,
       from,
       to,
       contextTags,
-      maxEvents
+      maxEvents,
+      transitionType,
+      group
     }) => {
       try {
         checkReadOnly(action, readOnly)
@@ -1179,6 +1222,23 @@ For generic event grouping (deployments, configs), use events tool instead.`,
                 site
               )
             )
+
+          case 'history': {
+            const monitorIdString = requireParam(id, 'id', 'history')
+            const monitorId = Number.parseInt(monitorIdString, 10)
+            if (Number.isNaN(monitorId)) {
+              throw new Error(`Invalid monitor ID: ${monitorIdString}`)
+            }
+            return toolResult(
+              await historyMonitor(
+                eventsApi,
+                monitorId,
+                { from, to, transitionType, group },
+                limits,
+                site
+              )
+            )
+          }
 
           default:
             throw new Error(`Unknown action: ${action}`)

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -470,7 +470,8 @@ function extractTimestamp(outer: { timestamp?: unknown }, inner: { timestamp?: u
     return outerTs.toISOString()
   }
   if (typeof outerTs === 'string' && outerTs.length > 0) {
-    return new Date(outerTs).toISOString()
+    const d = new Date(outerTs)
+    if (!Number.isNaN(d.getTime())) return d.toISOString()
   }
   const innerTs = inner.timestamp
   if (typeof innerTs === 'number' && Number.isFinite(innerTs)) {

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -419,7 +419,8 @@ export function buildMonitorHistoryQuery(params: {
   }
 
   if (params.group && params.group.length > 0) {
-    parts.push(`@monitor.groups:"${params.group}"`)
+    const escaped = params.group.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+    parts.push(`@monitor.groups:"${escaped}"`)
   }
 
   return parts.join(' ')

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -427,9 +427,12 @@ export function buildMonitorHistoryQuery(params: {
 
 /**
  * Shape of the `monitor.transition` block as observed in v2 event responses.
- * The SDK exposes `MonitorType.additionalProperties` for unknown keys, but at
- * runtime the deserializer keeps unknown keys directly on the object, so we
- * read it via a narrow runtime cast.
+ * The SDK's ObjectSerializer moves unknown keys (like `transition`) into
+ * `monitor.additionalProperties` because `transition` is not declared on the
+ * generated `MonitorType` model. Synthetic test events constructed in unit
+ * tests, on the other hand, keep `transition` directly on the monitor object.
+ * We support both shapes via the `additionalProperties` fallback in
+ * `formatMonitorTransition`.
  */
 interface RawMonitorTransition {
   source_state?: string
@@ -442,6 +445,7 @@ interface RawMonitorBlock {
   name?: string
   groups?: unknown
   transition?: RawMonitorTransition
+  additionalProperties?: { transition?: RawMonitorTransition }
 }
 
 function isMonitorState(value: unknown): value is MonitorState {
@@ -495,7 +499,15 @@ export function formatMonitorTransition(event: v2.EventResponse): MonitorTransit
     monitor?: unknown
   }
   const monitor = inner.monitor as RawMonitorBlock | undefined
-  const transition = monitor?.transition
+  if (!monitor) {
+    return null
+  }
+  // After SDK deserialization, unknown keys land in `monitor.additionalProperties`
+  // (see ObjectSerializer behaviour in node_modules/@datadog/datadog-api-client/
+  //  packages/datadog-api-client-v2/models/ObjectSerializer.js). Fall back to
+  //  that location so live API responses parse correctly while synthetic test
+  //  events keep working unchanged.
+  const transition = monitor.transition ?? monitor.additionalProperties?.transition
   if (!transition) {
     return null
   }

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -510,6 +510,122 @@ export function formatMonitorTransition(event: v2.EventResponse): MonitorTransit
   }
 }
 
+/**
+ * Orchestrate a `monitors action=history` query: paginate `eventsApi.searchEvents`,
+ * project each raw event via `formatMonitorTransition`, and return the structured
+ * `MonitorHistoryResponse`.
+ *
+ * Defaults follow the conventions of other event-based actions in this codebase:
+ * - Time range falls back to `hoursAgo(limits.defaultTimeRangeHours)` → `now()`.
+ * - `transitionType` defaults to `DEFAULT_HISTORY_TRANSITION_TYPES`
+ *   (`['alert', 'alert recovery']`) when undefined OR empty.
+ *
+ * Pagination is bounded identically to `aggregateEventsV2`:
+ * - `maxPages = 100`
+ * - `maxEventsToProcess = 10000`
+ * - per-page `limit = 1000`
+ *
+ * On cap hit, `meta.truncated` is set to `true`. The function is strictly
+ * read-only: it never calls any SDK method whose verb is
+ * `create`/`update`/`delete`/`mute`/`unmute`.
+ */
+export async function historyMonitor(
+  eventsApi: v2.EventsApi,
+  monitorId: number,
+  params: {
+    from?: string
+    to?: string
+    transitionType?: TransitionType[]
+    group?: string
+  },
+  limits: LimitsConfig,
+  site: string
+): Promise<MonitorHistoryResponse> {
+  // Time range setup — identical convention to topMonitors / searchEventsV2.
+  const defaultFrom = hoursAgo(limits.defaultTimeRangeHours)
+  const defaultTo = now()
+  const [validFrom, validTo] = ensureValidTimeRange(
+    parseTime(params.from, defaultFrom),
+    parseTime(params.to, defaultTo)
+  )
+  const fromTime = new Date(validFrom * 1000).toISOString()
+  const toTime = new Date(validTo * 1000).toISOString()
+
+  // Empty array → undefined → default per design's error-handling table.
+  const effectiveTransitionTypes: TransitionType[] =
+    params.transitionType && params.transitionType.length > 0
+      ? params.transitionType
+      : [...DEFAULT_HISTORY_TRANSITION_TYPES]
+
+  const query = buildMonitorHistoryQuery({
+    monitorId,
+    transitionType: effectiveTransitionTypes,
+    group: params.group
+  })
+
+  const transitions: MonitorTransition[] = []
+  const maxEventsToProcess = 10000
+  const maxPages = 100
+  let eventCount = 0
+  let pageCount = 0
+
+  const body: v2.EventsListRequest = {
+    filter: {
+      query,
+      from: fromTime,
+      to: toTime
+    },
+    sort: 'timestamp' as v2.EventsSort,
+    page: { limit: 1000 }
+  }
+
+  let cursor: string | undefined
+
+  while (pageCount < maxPages && eventCount < maxEventsToProcess) {
+    const pageBody = { ...body, page: { ...body.page, cursor } }
+    const response = await eventsApi.searchEvents({ body: pageBody })
+
+    const events = response.data ?? []
+    if (events.length === 0) break
+
+    for (const event of events) {
+      const transition = formatMonitorTransition(event)
+      if (transition !== null) {
+        transitions.push(transition)
+      }
+      eventCount++
+      if (eventCount >= maxEventsToProcess) break
+    }
+
+    cursor = response.meta?.page?.after
+    if (!cursor) break
+    pageCount++
+  }
+
+  const truncated = eventCount >= maxEventsToProcess
+  const resolvedGroup = params.group && params.group.length > 0 ? params.group : null
+  const count = transitions.length
+
+  const meta: MonitorHistoryMeta = {
+    monitorId,
+    query,
+    from: fromTime,
+    to: toTime,
+    transitionTypes: effectiveTransitionTypes,
+    group: resolvedGroup,
+    count,
+    totalFetched: eventCount,
+    truncated,
+    datadog_url: buildEventsUrl(query, validFrom, validTo, site)
+  }
+
+  return {
+    transitions,
+    count,
+    meta
+  }
+}
+
 export async function listMonitors(
   api: v1.MonitorsApi,
   params: { name?: string; tags?: string[]; groupStates?: string[]; limit?: number },

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -292,6 +292,224 @@ export function formatMonitorDetail(m: v1.Monitor, site: string = 'datadoghq.com
   return detail
 }
 
+// ============ Monitor State History (action=history) types and helpers ============
+
+/**
+ * Monitor transition types as exposed by Datadog's
+ * `@monitor.transition.transition_type` facet on v2 events.
+ *
+ * - 'alert' / 'warning' / 'no data' are forward transitions (OK/Warn → Alert, etc.)
+ * - '<state> recovery' transitions are returns to OK
+ * - 'renotify' is a repeated notification while the monitor is stuck in a non-OK
+ *   state — it is NOT a state transition and is excluded by default.
+ */
+export type TransitionType =
+  | 'alert'
+  | 'alert recovery'
+  | 'warning'
+  | 'warning recovery'
+  | 'no data'
+  | 'no data recovery'
+  | 'renotify'
+
+/** Datadog monitor state values used in `source_state` / `destination_state`. */
+export type MonitorState = 'Alert' | 'Warn' | 'OK' | 'No Data'
+
+/** A single state transition extracted from a v2 events `source:alert` payload. */
+export interface MonitorTransition {
+  /** ISO 8601 timestamp of the transition. */
+  timestamp: string
+  monitorId: number
+  monitorName: string
+  /** Joined `monitor.groups` array (comma-separated) or `null` when not multi-alert. */
+  group: string | null
+  fromState: MonitorState
+  toState: MonitorState
+  transitionType: TransitionType
+  /** Event ID for cross-reference with the events tool. */
+  eventId: string
+}
+
+/** Metadata describing the request and post-filter shape of a history call. */
+export interface MonitorHistoryMeta {
+  monitorId: number
+  query: string
+  from: string
+  to: string
+  transitionTypes: TransitionType[]
+  group: string | null
+  count: number
+  totalFetched: number
+  truncated: boolean
+  datadog_url: string
+}
+
+/** Full response shape for `monitors action=history`. */
+export interface MonitorHistoryResponse {
+  transitions: MonitorTransition[]
+  count: number
+  meta: MonitorHistoryMeta
+}
+
+/** Default transition_type filter applied by `monitors action=history`. */
+export const DEFAULT_HISTORY_TRANSITION_TYPES: readonly TransitionType[] = [
+  'alert',
+  'alert recovery'
+]
+
+/**
+ * Quote a value for inclusion in a Datadog event search query.
+ * Multi-word values (containing whitespace) and values containing characters
+ * other than a small safe set get wrapped in double quotes; single-word safe
+ * values stay unquoted to match the verbatim shape observed in the live
+ * investigation (see design.md "Investigation log").
+ */
+function quoteIfNeeded(value: string): string {
+  // Safe = letters, digits, underscore, hyphen, dot — Datadog accepts these unquoted.
+  return /^[A-Za-z0-9_.-]+$/.test(value) ? value : `"${value}"`
+}
+
+/**
+ * Compose the Datadog event search `filter.query` for `monitors action=history`.
+ *
+ * Always emits `source:alert @monitor.id:N`. When `transitionType` is a non-empty
+ * array, appends `@monitor.transition.transition_type:(a OR "b c" OR ...)` with
+ * multi-word values quoted. When `group` is non-empty, appends
+ * `@monitor.groups:"<group>"`.
+ *
+ * An empty `transitionType: []` is treated as undefined per design (no clause).
+ */
+export function buildMonitorHistoryQuery(params: {
+  monitorId: number
+  transitionType?: TransitionType[]
+  group?: string
+}): string {
+  const parts: string[] = ['source:alert', `@monitor.id:${params.monitorId}`]
+
+  const transitionTypes =
+    params.transitionType && params.transitionType.length > 0 ? params.transitionType : undefined
+
+  if (transitionTypes) {
+    const inner = transitionTypes.map(quoteIfNeeded).join(' OR ')
+    parts.push(`@monitor.transition.transition_type:(${inner})`)
+  }
+
+  if (params.group && params.group.length > 0) {
+    parts.push(`@monitor.groups:"${params.group}"`)
+  }
+
+  return parts.join(' ')
+}
+
+/**
+ * Shape of the `monitor.transition` block as observed in v2 event responses.
+ * The SDK exposes `MonitorType.additionalProperties` for unknown keys, but at
+ * runtime the deserializer keeps unknown keys directly on the object, so we
+ * read it via a narrow runtime cast.
+ */
+interface RawMonitorTransition {
+  source_state?: string
+  destination_state?: string
+  transition_type?: string
+}
+
+interface RawMonitorBlock {
+  id?: number
+  name?: string
+  groups?: unknown
+  transition?: RawMonitorTransition
+}
+
+function isMonitorState(value: unknown): value is MonitorState {
+  return value === 'Alert' || value === 'Warn' || value === 'OK' || value === 'No Data'
+}
+
+function isTransitionType(value: unknown): value is TransitionType {
+  return (
+    value === 'alert' ||
+    value === 'alert recovery' ||
+    value === 'warning' ||
+    value === 'warning recovery' ||
+    value === 'no data' ||
+    value === 'no data recovery' ||
+    value === 'renotify'
+  )
+}
+
+function extractTimestamp(outer: { timestamp?: unknown }, inner: { timestamp?: unknown }): string {
+  const outerTs = outer.timestamp
+  if (outerTs instanceof Date) {
+    return outerTs.toISOString()
+  }
+  if (typeof outerTs === 'string' && outerTs.length > 0) {
+    return new Date(outerTs).toISOString()
+  }
+  const innerTs = inner.timestamp
+  if (typeof innerTs === 'number' && Number.isFinite(innerTs)) {
+    return new Date(innerTs).toISOString()
+  }
+  if (typeof innerTs === 'string' && innerTs.length > 0) {
+    const parsed = Number.parseInt(innerTs, 10)
+    if (!Number.isNaN(parsed)) {
+      return new Date(parsed).toISOString()
+    }
+  }
+  return ''
+}
+
+/**
+ * Project a raw v2 `EventResponse` to a typed `MonitorTransition`.
+ *
+ * Returns `null` when the event lacks an `attributes.attributes.monitor.transition`
+ * block — for example renotify rows that slip past a stale filter, or non-monitor
+ * events. The caller is expected to drop nulls before counting.
+ */
+export function formatMonitorTransition(event: v2.EventResponse): MonitorTransition | null {
+  const outer = (event.attributes ?? {}) as { timestamp?: unknown; attributes?: unknown }
+  const inner = (outer.attributes ?? {}) as {
+    timestamp?: unknown
+    monitor?: unknown
+  }
+  const monitor = inner.monitor as RawMonitorBlock | undefined
+  const transition = monitor?.transition
+  if (!transition) {
+    return null
+  }
+
+  const fromState = isMonitorState(transition.source_state) ? transition.source_state : null
+  const toState = isMonitorState(transition.destination_state) ? transition.destination_state : null
+  const transitionType = isTransitionType(transition.transition_type)
+    ? transition.transition_type
+    : null
+
+  if (!fromState || !toState || !transitionType) {
+    return null
+  }
+
+  const groupsRaw = monitor.groups
+  const group =
+    Array.isArray(groupsRaw) && groupsRaw.length > 0
+      ? groupsRaw.map((g) => String(g)).join(',')
+      : null
+
+  const monitorId = typeof monitor.id === 'number' ? monitor.id : 0
+  const monitorName =
+    typeof monitor.name === 'string' && monitor.name.length > 0
+      ? monitor.name
+      : `Monitor ${monitorId}`
+
+  return {
+    timestamp: extractTimestamp(outer, inner),
+    monitorId,
+    monitorName,
+    group,
+    fromState,
+    toState,
+    transitionType,
+    eventId: String(event.id ?? '')
+  }
+}
+
 export async function listMonitors(
   api: v1.MonitorsApi,
   params: { name?: string; tags?: string[]; groupStates?: string[]; limit?: number },

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1478,6 +1478,362 @@ export const notebooks = {
   }
 }
 
+// Monitor history fixtures (v2 events search responses for monitors action=history)
+// Event shape matches Datadog's live API as captured in the design's Investigation log:
+//   attributes.attributes.monitor.transition.{source_state, destination_state, transition_type}
+//   attributes.attributes.monitor.{id, name, groups}
+//
+// Dispatch in tests/helpers/msw.ts keys off the @monitor.id:<N> filter:
+//   1001 → monitorHistoryAlertOnly
+//   1002 → monitorHistoryMixed
+//   1003 → monitorHistoryDynamicTitle (issue #53 regression — unique titles per event)
+//   1004 → monitorHistoryMultiPage (cursor "page2")
+//   1005 → monitorHistoryEmpty
+export const monitorHistoryFixtures = {
+  alertOnly: {
+    data: [
+      {
+        id: 'evt-mh-1001-001',
+        type: 'event',
+        attributes: {
+          timestamp: '2026-05-13T10:00:00.000Z',
+          tags: ['source:alert', 'monitor_id:1001'],
+          attributes: {
+            title: '[Triggered on {pod_name:foo}] Pod readiness production',
+            message: 'Pod readiness is below threshold',
+            monitor: {
+              id: 1001,
+              name: '[DO-1712] Pod readiness production',
+              groups: ['kube_namespace:production', 'pod_name:foo'],
+              transition: {
+                source_state: 'OK',
+                destination_state: 'Alert',
+                transition_type: 'alert'
+              }
+            }
+          }
+        }
+      }
+    ],
+    meta: {
+      page: {
+        after: null
+      }
+    }
+  },
+  mixed: {
+    data: [
+      {
+        id: 'evt-mh-1002-001',
+        type: 'event',
+        attributes: {
+          timestamp: '2026-05-13T09:00:00.000Z',
+          tags: ['source:alert', 'monitor_id:1002'],
+          attributes: {
+            title: '[Triggered on {host:prod-1}] Mixed monitor',
+            message: 'Threshold breached',
+            monitor: {
+              id: 1002,
+              name: 'Mixed monitor',
+              groups: ['host:prod-1'],
+              transition: {
+                source_state: 'OK',
+                destination_state: 'Alert',
+                transition_type: 'alert'
+              }
+            }
+          }
+        }
+      },
+      {
+        id: 'evt-mh-1002-002',
+        type: 'event',
+        attributes: {
+          timestamp: '2026-05-13T09:05:00.000Z',
+          tags: ['source:alert', 'monitor_id:1002'],
+          attributes: {
+            title: '[Renotify on {host:prod-1}] Mixed monitor',
+            message: 'Still firing',
+            monitor: {
+              id: 1002,
+              name: 'Mixed monitor',
+              groups: ['host:prod-1'],
+              transition: {
+                source_state: 'Alert',
+                destination_state: 'Alert',
+                transition_type: 'renotify'
+              }
+            }
+          }
+        }
+      },
+      {
+        id: 'evt-mh-1002-003',
+        type: 'event',
+        attributes: {
+          timestamp: '2026-05-13T09:10:00.000Z',
+          tags: ['source:alert', 'monitor_id:1002'],
+          attributes: {
+            title: '[Renotify on {host:prod-1}] Mixed monitor',
+            message: 'Still firing',
+            monitor: {
+              id: 1002,
+              name: 'Mixed monitor',
+              groups: ['host:prod-1'],
+              transition: {
+                source_state: 'Alert',
+                destination_state: 'Alert',
+                transition_type: 'renotify'
+              }
+            }
+          }
+        }
+      },
+      {
+        id: 'evt-mh-1002-004',
+        type: 'event',
+        attributes: {
+          timestamp: '2026-05-13T09:15:00.000Z',
+          tags: ['source:alert', 'monitor_id:1002'],
+          attributes: {
+            title: '[Recovered on {host:prod-1}] Mixed monitor',
+            message: 'Returned to OK',
+            monitor: {
+              id: 1002,
+              name: 'Mixed monitor',
+              groups: ['host:prod-1'],
+              transition: {
+                source_state: 'Alert',
+                destination_state: 'OK',
+                transition_type: 'alert recovery'
+              }
+            }
+          }
+        }
+      }
+    ],
+    meta: {
+      page: {
+        after: null
+      }
+    }
+  },
+  // Issue #53 regression fixture: an SLO burn-rate-style monitor that emits a
+  // different title on every event. Stale dedup-by-title logic collapses these
+  // to 1; the correct behavior is to count each real transition (5 total here:
+  // 3 alert + 2 alert recovery), and zero "renotify" rows are included so the
+  // default filter ['alert','alert recovery'] returns all 5.
+  dynamicTitle: {
+    data: [
+      {
+        id: 'evt-mh-1003-001',
+        type: 'event',
+        attributes: {
+          timestamp: '2026-05-13T08:00:00.000Z',
+          tags: ['source:alert', 'monitor_id:1003'],
+          attributes: {
+            title: 'SLO burn rates of 6.01 and 12.01 above threshold',
+            message: 'Burn rate exceeded',
+            monitor: {
+              id: 1003,
+              name: 'SLO burn-rate monitor',
+              groups: ['service:api'],
+              transition: {
+                source_state: 'OK',
+                destination_state: 'Alert',
+                transition_type: 'alert'
+              }
+            }
+          }
+        }
+      },
+      {
+        id: 'evt-mh-1003-002',
+        type: 'event',
+        attributes: {
+          timestamp: '2026-05-13T08:30:00.000Z',
+          tags: ['source:alert', 'monitor_id:1003'],
+          attributes: {
+            title: 'SLO recovered (burn rates back under threshold)',
+            message: 'Recovered',
+            monitor: {
+              id: 1003,
+              name: 'SLO burn-rate monitor',
+              groups: ['service:api'],
+              transition: {
+                source_state: 'Alert',
+                destination_state: 'OK',
+                transition_type: 'alert recovery'
+              }
+            }
+          }
+        }
+      },
+      {
+        id: 'evt-mh-1003-003',
+        type: 'event',
+        attributes: {
+          timestamp: '2026-05-13T09:00:00.000Z',
+          tags: ['source:alert', 'monitor_id:1003'],
+          attributes: {
+            title: 'SLO burn rates of 8.04 and 5.77 above threshold',
+            message: 'Burn rate exceeded',
+            monitor: {
+              id: 1003,
+              name: 'SLO burn-rate monitor',
+              groups: ['service:api'],
+              transition: {
+                source_state: 'OK',
+                destination_state: 'Alert',
+                transition_type: 'alert'
+              }
+            }
+          }
+        }
+      },
+      {
+        id: 'evt-mh-1003-004',
+        type: 'event',
+        attributes: {
+          timestamp: '2026-05-13T09:30:00.000Z',
+          tags: ['source:alert', 'monitor_id:1003'],
+          attributes: {
+            title: 'SLO recovered (burn rates back under threshold)',
+            message: 'Recovered',
+            monitor: {
+              id: 1003,
+              name: 'SLO burn-rate monitor',
+              groups: ['service:api'],
+              transition: {
+                source_state: 'Alert',
+                destination_state: 'OK',
+                transition_type: 'alert recovery'
+              }
+            }
+          }
+        }
+      },
+      {
+        id: 'evt-mh-1003-005',
+        type: 'event',
+        attributes: {
+          timestamp: '2026-05-13T10:00:00.000Z',
+          tags: ['source:alert', 'monitor_id:1003'],
+          attributes: {
+            title: 'SLO burn rates of 9.0 and 4.2 above threshold',
+            message: 'Burn rate exceeded',
+            monitor: {
+              id: 1003,
+              name: 'SLO burn-rate monitor',
+              groups: ['service:api'],
+              transition: {
+                source_state: 'OK',
+                destination_state: 'Alert',
+                transition_type: 'alert'
+              }
+            }
+          }
+        }
+      }
+    ],
+    meta: {
+      page: {
+        after: null
+      }
+    }
+  },
+  multiPage: {
+    page1: {
+      data: [
+        {
+          id: 'evt-mh-1004-001',
+          type: 'event',
+          attributes: {
+            timestamp: '2026-05-13T07:00:00.000Z',
+            tags: ['source:alert', 'monitor_id:1004'],
+            attributes: {
+              title: '[Triggered] Multi-page monitor first',
+              message: 'First page event',
+              monitor: {
+                id: 1004,
+                name: 'Multi-page monitor',
+                groups: ['env:production'],
+                transition: {
+                  source_state: 'OK',
+                  destination_state: 'Alert',
+                  transition_type: 'alert'
+                }
+              }
+            }
+          }
+        },
+        {
+          id: 'evt-mh-1004-002',
+          type: 'event',
+          attributes: {
+            timestamp: '2026-05-13T07:15:00.000Z',
+            tags: ['source:alert', 'monitor_id:1004'],
+            attributes: {
+              title: '[Recovered] Multi-page monitor first',
+              message: 'First page recovery',
+              monitor: {
+                id: 1004,
+                name: 'Multi-page monitor',
+                groups: ['env:production'],
+                transition: {
+                  source_state: 'Alert',
+                  destination_state: 'OK',
+                  transition_type: 'alert recovery'
+                }
+              }
+            }
+          }
+        }
+      ],
+      meta: {
+        page: {
+          after: 'page2'
+        }
+      }
+    },
+    page2: {
+      data: [
+        {
+          id: 'evt-mh-1004-003',
+          type: 'event',
+          attributes: {
+            timestamp: '2026-05-13T08:00:00.000Z',
+            tags: ['source:alert', 'monitor_id:1004'],
+            attributes: {
+              title: '[Triggered] Multi-page monitor second',
+              message: 'Second page event',
+              monitor: {
+                id: 1004,
+                name: 'Multi-page monitor',
+                groups: ['env:production'],
+                transition: {
+                  source_state: 'OK',
+                  destination_state: 'Alert',
+                  transition_type: 'alert'
+                }
+              }
+            }
+          }
+        }
+      ],
+      meta: {
+        page: {
+          after: null
+        }
+      }
+    }
+  },
+  empty: {
+    data: [],
+    meta: {}
+  }
+}
+
 // P4 Tools Fixtures
 
 // Tags fixtures

--- a/tests/helpers/msw.ts
+++ b/tests/helpers/msw.ts
@@ -3,6 +3,7 @@
  */
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
+import { monitorHistoryFixtures } from './fixtures.js'
 
 // Datadog API base URLs
 export const DD_API_V1 = 'https://api.datadoghq.com/api/v1'
@@ -188,6 +189,62 @@ export function createErrorHandlers(endpoint: string) {
     rateLimited: http.all(endpoint, () => errorResponse(429, 'Rate limit exceeded')),
     serverError: http.all(endpoint, () => errorResponse(500, 'Internal server error'))
   }
+}
+
+/**
+ * MSW handler for POST /api/v2/events/search that dispatches monitor-history
+ * fixtures based on the @monitor.id:<N> filter in the request body.
+ *
+ * Mapping:
+ *   1001 → monitorHistoryFixtures.alertOnly
+ *   1002 → monitorHistoryFixtures.mixed
+ *   1003 → monitorHistoryFixtures.dynamicTitle (issue #53 regression case)
+ *   1004 → monitorHistoryFixtures.multiPage — page1 first, page2 when
+ *          body.page.cursor === "page2"
+ *   1005 → monitorHistoryFixtures.empty
+ *
+ * Unknown monitor IDs return a 404 so tests fail loudly rather than
+ * silently masking a routing bug.
+ */
+export function monitorHistoryEventsSearchHandler() {
+  return http.post(endpoints.searchEvents, async ({ request }) => {
+    const body = (await request.json()) as {
+      filter?: { query?: string }
+      page?: { cursor?: string }
+    }
+    const query = body.filter?.query ?? ''
+    const cursor = body.page?.cursor
+
+    const match = /@monitor\.id:(\d+)/.exec(query)
+    if (!match) {
+      return errorResponse(
+        400,
+        `monitorHistoryEventsSearchHandler: no @monitor.id in query: ${query}`
+      )
+    }
+    const monitorId = match[1]
+
+    switch (monitorId) {
+      case '1001':
+        return jsonResponse(monitorHistoryFixtures.alertOnly)
+      case '1002':
+        return jsonResponse(monitorHistoryFixtures.mixed)
+      case '1003':
+        return jsonResponse(monitorHistoryFixtures.dynamicTitle)
+      case '1004':
+        if (cursor === 'page2') {
+          return jsonResponse(monitorHistoryFixtures.multiPage.page2)
+        }
+        return jsonResponse(monitorHistoryFixtures.multiPage.page1)
+      case '1005':
+        return jsonResponse(monitorHistoryFixtures.empty)
+      default:
+        return errorResponse(
+          404,
+          `monitorHistoryEventsSearchHandler: no fixture for @monitor.id:${monitorId}`
+        )
+    }
+  })
 }
 
 export { http, HttpResponse }

--- a/tests/tools/events.test.ts
+++ b/tests/tools/events.test.ts
@@ -214,4 +214,164 @@ describe('Events Tool', () => {
       })
     })
   })
+
+  describe('searchEventsV2 with transitionType filter', () => {
+    interface CapturedBody {
+      filter?: { query?: string; from?: string; to?: string }
+      sort?: string
+      page?: { limit?: number; cursor?: string }
+    }
+
+    /**
+     * Install a handler that records the request body so the test can assert
+     * the exact `filter.query` string emitted by buildEventQuery via
+     * searchEventsV2. Returns a getter for the latest captured body.
+     */
+    function installCapturingHandler(): () => CapturedBody | undefined {
+      let captured: CapturedBody | undefined
+      server.use(
+        http.post(endpoints.searchEvents, async ({ request }) => {
+          captured = (await request.json()) as CapturedBody
+          return jsonResponse(fixtures.searchV2)
+        })
+      )
+      return () => captured
+    }
+
+    it('produces a byte-identical filter.query when transitionType is omitted (requirement 5.1)', async () => {
+      // Baseline: call without transitionType
+      const getBaseline = installCapturingHandler()
+      await searchEventsV2(
+        apiV2,
+        {
+          query: 'source:alert',
+          tags: ['env:prod'],
+          from: '2024-01-20T00:00:00Z',
+          to: '2024-01-20T23:59:59Z'
+        },
+        defaultLimits,
+        defaultSite
+      )
+      const baselineQuery = getBaseline()?.filter?.query
+      expect(baselineQuery).toBeDefined()
+
+      // Reset MSW handlers and install a fresh capturing handler. The second
+      // call passes transitionType explicitly as undefined to prove the
+      // shape is byte-identical to omission.
+      server.resetHandlers()
+      const getActual = installCapturingHandler()
+      await searchEventsV2(
+        apiV2,
+        {
+          query: 'source:alert',
+          tags: ['env:prod'],
+          from: '2024-01-20T00:00:00Z',
+          to: '2024-01-20T23:59:59Z',
+          transitionType: undefined
+        },
+        defaultLimits,
+        defaultSite
+      )
+
+      expect(getActual()?.filter?.query).toBe(baselineQuery)
+      // Negative guard: the additive clause must NOT appear when omitted
+      expect(baselineQuery).not.toContain('@monitor.transition.transition_type')
+    })
+
+    it('produces the same filter.query for empty transitionType as for omitted transitionType', async () => {
+      const getBaseline = installCapturingHandler()
+      await searchEventsV2(
+        apiV2,
+        {
+          query: 'source:alert',
+          from: '2024-01-20T00:00:00Z',
+          to: '2024-01-20T23:59:59Z'
+        },
+        defaultLimits,
+        defaultSite
+      )
+      const baselineQuery = getBaseline()?.filter?.query
+
+      server.resetHandlers()
+      const getEmpty = installCapturingHandler()
+      await searchEventsV2(
+        apiV2,
+        {
+          query: 'source:alert',
+          from: '2024-01-20T00:00:00Z',
+          to: '2024-01-20T23:59:59Z',
+          transitionType: []
+        },
+        defaultLimits,
+        defaultSite
+      )
+
+      expect(getEmpty()?.filter?.query).toBe(baselineQuery)
+      expect(getEmpty()?.filter?.query).not.toContain('@monitor.transition.transition_type')
+    })
+
+    it('appends @monitor.transition.transition_type with OR for multi-valued input', async () => {
+      const getBody = installCapturingHandler()
+      await searchEventsV2(
+        apiV2,
+        {
+          query: 'source:alert',
+          from: '2024-01-20T00:00:00Z',
+          to: '2024-01-20T23:59:59Z',
+          transitionType: ['alert', 'warning']
+        },
+        defaultLimits,
+        defaultSite
+      )
+
+      const query = getBody()?.filter?.query
+      expect(query).toBeDefined()
+      // Clause is present and OR'd, multi-word values that aren't here stay unquoted
+      expect(query).toContain('@monitor.transition.transition_type:(alert OR warning)')
+      // The original user query is preserved as a leading clause
+      expect(query?.startsWith('source:alert ')).toBe(true)
+    })
+
+    it('quotes multi-word transition types like "alert recovery"', async () => {
+      const getBody = installCapturingHandler()
+      await searchEventsV2(
+        apiV2,
+        {
+          query: 'source:alert',
+          from: '2024-01-20T00:00:00Z',
+          to: '2024-01-20T23:59:59Z',
+          transitionType: ['alert', 'alert recovery']
+        },
+        defaultLimits,
+        defaultSite
+      )
+
+      const query = getBody()?.filter?.query
+      expect(query).toBeDefined()
+      expect(query).toContain('@monitor.transition.transition_type:(alert OR "alert recovery")')
+      // Single-word values must remain unquoted in the same clause
+      expect(query).not.toContain('"alert"')
+    })
+
+    it('emits a single-valued clause without an OR when only one transition type is provided', async () => {
+      const getBody = installCapturingHandler()
+      await searchEventsV2(
+        apiV2,
+        {
+          query: 'source:alert',
+          from: '2024-01-20T00:00:00Z',
+          to: '2024-01-20T23:59:59Z',
+          transitionType: ['alert recovery']
+        },
+        defaultLimits,
+        defaultSite
+      )
+
+      const query = getBody()?.filter?.query
+      expect(query).toContain('@monitor.transition.transition_type:("alert recovery")')
+      // With a single value there must be no ` OR ` token inside the clause
+      const clauseMatch = /@monitor\.transition\.transition_type:\(([^)]*)\)/.exec(query ?? '')
+      expect(clauseMatch?.[1]).toBe('"alert recovery"')
+    })
+  })
 })

--- a/tests/tools/monitors-helpers.test.ts
+++ b/tests/tools/monitors-helpers.test.ts
@@ -2,12 +2,14 @@
  * Tests for monitors.ts helper functions
  * Focus on normalizeMonitorConfig which is completely untested (lines 146-194)
  */
-import { describe, it, expect } from 'vitest'
+import type { v2 } from '@datadog/datadog-api-client'
 import {
   normalizeMonitorConfig,
   collectUnknownKeyWarnings,
   MonitorConfigSchema,
-  MonitorOptionsSchema
+  MonitorOptionsSchema,
+  formatMonitorTransition,
+  buildMonitorHistoryQuery
 } from '../../src/tools/monitors.js'
 
 describe('Monitors Helper Functions', () => {
@@ -784,5 +786,245 @@ describe('MonitorConfigSchema — top-level rejection', () => {
     if (!result.success) {
       expect(result.error.issues[0]?.path).toEqual(['options', 'notifyNoData'])
     }
+  })
+
+  describe('buildMonitorHistoryQuery', () => {
+    it('always emits source:alert @monitor.id:N as the base query (no clause when transitionType is omitted)', () => {
+      // Per design, buildMonitorHistoryQuery is a pure composer: the
+      // historyMonitor orchestrator owns the default ['alert', 'alert recovery'].
+      // When transitionType is undefined here, the helper emits only the base.
+      const query = buildMonitorHistoryQuery({ monitorId: 282774192 })
+      expect(query).toBe('source:alert @monitor.id:282774192')
+      expect(query).not.toContain('@monitor.transition.transition_type')
+      expect(query).not.toContain('@monitor.groups')
+    })
+
+    it('emits the default ["alert", "alert recovery"] clause when the orchestrator passes the default', () => {
+      // Mirrors design.md "Unit tests for helpers" — query with default
+      // transition types should produce the canonical fires + recoveries form.
+      const query = buildMonitorHistoryQuery({
+        monitorId: 282774192,
+        transitionType: ['alert', 'alert recovery']
+      })
+      expect(query).toBe(
+        'source:alert @monitor.id:282774192 @monitor.transition.transition_type:(alert OR "alert recovery")'
+      )
+    })
+
+    it('appends an OR-joined transition_type clause for multiple values with proper quoting', () => {
+      const query = buildMonitorHistoryQuery({
+        monitorId: 12345,
+        transitionType: ['alert', 'alert recovery', 'renotify']
+      })
+      expect(query).toBe(
+        'source:alert @monitor.id:12345 @monitor.transition.transition_type:(alert OR "alert recovery" OR renotify)'
+      )
+    })
+
+    it('emits a single-value transition_type clause without parentheses padding errors', () => {
+      const query = buildMonitorHistoryQuery({
+        monitorId: 42,
+        transitionType: ['alert']
+      })
+      expect(query).toBe('source:alert @monitor.id:42 @monitor.transition.transition_type:(alert)')
+    })
+
+    it('appends @monitor.groups:"..." when group is provided and quotes the value', () => {
+      const query = buildMonitorHistoryQuery({
+        monitorId: 282774192,
+        transitionType: ['alert'],
+        group: 'pod_name:cronjob-mover-29644980-jnvpj'
+      })
+      expect(query).toBe(
+        'source:alert @monitor.id:282774192 @monitor.transition.transition_type:(alert) @monitor.groups:"pod_name:cronjob-mover-29644980-jnvpj"'
+      )
+    })
+
+    it('treats empty transitionType array as undefined (no clause appended)', () => {
+      const query = buildMonitorHistoryQuery({
+        monitorId: 7,
+        transitionType: []
+      })
+      expect(query).toBe('source:alert @monitor.id:7')
+      expect(query).not.toContain('@monitor.transition.transition_type')
+    })
+
+    it('omits the group clause when group is undefined or empty', () => {
+      const noGroup = buildMonitorHistoryQuery({
+        monitorId: 7,
+        transitionType: ['alert']
+      })
+      expect(noGroup).not.toContain('@monitor.groups')
+
+      const emptyGroup = buildMonitorHistoryQuery({
+        monitorId: 7,
+        transitionType: ['alert'],
+        group: ''
+      })
+      expect(emptyGroup).not.toContain('@monitor.groups')
+    })
+  })
+
+  describe('formatMonitorTransition', () => {
+    it('extracts a typed transition from a v2 event with monitor.transition present', () => {
+      const event = {
+        id: 'evt-1',
+        attributes: {
+          timestamp: new Date('2026-05-13T23:24:00.000Z'),
+          attributes: {
+            timestamp: 1747178640000,
+            monitor: {
+              id: 282774192,
+              name: '[DO-1712] Pod readiness production',
+              groups: ['kube_namespace:production', 'pod_name:foo'],
+              transition: {
+                source_state: 'Alert',
+                destination_state: 'OK',
+                transition_type: 'alert recovery'
+              }
+            }
+          }
+        }
+      } as unknown as v2.EventResponse
+
+      const transition = formatMonitorTransition(event)
+
+      expect(transition).not.toBeNull()
+      expect(transition).toMatchObject({
+        timestamp: '2026-05-13T23:24:00.000Z',
+        monitorId: 282774192,
+        monitorName: '[DO-1712] Pod readiness production',
+        fromState: 'Alert',
+        toState: 'OK',
+        transitionType: 'alert recovery',
+        eventId: 'evt-1'
+      })
+      // groups is joined by ',' per design when multi-value
+      expect(transition?.group).toBe('kube_namespace:production,pod_name:foo')
+    })
+
+    it('returns null when the monitor.transition block is absent', () => {
+      const event = {
+        id: 'evt-2',
+        attributes: {
+          timestamp: new Date('2026-05-13T23:24:00.000Z'),
+          attributes: {
+            monitor: {
+              id: 282774192,
+              name: '[DO-1712] Pod readiness production',
+              groups: ['kube_namespace:production']
+              // no transition block
+            }
+          }
+        }
+      } as unknown as v2.EventResponse
+
+      expect(formatMonitorTransition(event)).toBeNull()
+    })
+
+    it('returns null when the outer attributes or inner monitor are missing', () => {
+      expect(formatMonitorTransition({} as v2.EventResponse)).toBeNull()
+      expect(formatMonitorTransition({ attributes: {} } as unknown as v2.EventResponse)).toBeNull()
+      expect(
+        formatMonitorTransition({
+          attributes: { attributes: {} }
+        } as unknown as v2.EventResponse)
+      ).toBeNull()
+    })
+
+    it('preserves group as null for non-multi-alert monitors (no groups array)', () => {
+      const event = {
+        id: 'evt-3',
+        attributes: {
+          timestamp: new Date('2026-05-13T23:24:00.000Z'),
+          attributes: {
+            monitor: {
+              id: 100,
+              name: 'Simple Monitor',
+              // no groups field
+              transition: {
+                source_state: 'OK',
+                destination_state: 'Alert',
+                transition_type: 'alert'
+              }
+            }
+          }
+        }
+      } as unknown as v2.EventResponse
+
+      const transition = formatMonitorTransition(event)
+      expect(transition).not.toBeNull()
+      expect(transition?.group).toBeNull()
+      expect(transition?.fromState).toBe('OK')
+      expect(transition?.toState).toBe('Alert')
+      expect(transition?.transitionType).toBe('alert')
+    })
+
+    it('preserves group as null when the groups array is empty', () => {
+      const event = {
+        id: 'evt-4',
+        attributes: {
+          timestamp: new Date('2026-05-13T23:24:00.000Z'),
+          attributes: {
+            monitor: {
+              id: 101,
+              name: 'Empty groups',
+              groups: [],
+              transition: {
+                source_state: 'OK',
+                destination_state: 'Alert',
+                transition_type: 'alert'
+              }
+            }
+          }
+        }
+      } as unknown as v2.EventResponse
+
+      expect(formatMonitorTransition(event)?.group).toBeNull()
+    })
+
+    it('falls back to "Monitor ${id}" when monitor name is missing', () => {
+      const event = {
+        id: 'evt-5',
+        attributes: {
+          timestamp: new Date('2026-05-13T23:24:00.000Z'),
+          attributes: {
+            monitor: {
+              id: 999,
+              transition: {
+                source_state: 'OK',
+                destination_state: 'Alert',
+                transition_type: 'alert'
+              }
+            }
+          }
+        }
+      } as unknown as v2.EventResponse
+
+      expect(formatMonitorTransition(event)?.monitorName).toBe('Monitor 999')
+    })
+
+    it('uses numeric timestamp at the inner attributes when the outer Date is absent', () => {
+      const event = {
+        id: 'evt-6',
+        attributes: {
+          // no outer timestamp Date
+          attributes: {
+            timestamp: 1747178640000,
+            monitor: {
+              id: 1,
+              name: 'X',
+              transition: {
+                source_state: 'OK',
+                destination_state: 'Alert',
+                transition_type: 'alert'
+              }
+            }
+          }
+        }
+      } as unknown as v2.EventResponse
+
+      expect(formatMonitorTransition(event)?.timestamp).toBe(new Date(1747178640000).toISOString())
+    })
   })
 })

--- a/tests/tools/monitors-helpers.test.ts
+++ b/tests/tools/monitors-helpers.test.ts
@@ -1017,6 +1017,48 @@ describe('MonitorConfigSchema — top-level rejection', () => {
       expect(formatMonitorTransition(event)?.monitorName).toBe('Monitor 999')
     })
 
+    it('reads the transition from monitor.additionalProperties when the SDK moves unknown keys there', () => {
+      // The Datadog SDK's ObjectSerializer deserializes unknown properties
+      // (like `transition`, which is not declared on the generated MonitorType)
+      // into a `monitor.additionalProperties` bag. formatMonitorTransition must
+      // fall back to that location so live API responses parse correctly.
+      const event = {
+        id: 'evt-ap',
+        attributes: {
+          timestamp: new Date('2026-05-13T23:24:00.000Z'),
+          attributes: {
+            monitor: {
+              id: 282774192,
+              name: '[DO-1712] Pod readiness production',
+              groups: ['kube_namespace:production'],
+              // No top-level transition — only the SDK-deserialized shape.
+              additionalProperties: {
+                transition: {
+                  source_state: 'Alert',
+                  destination_state: 'OK',
+                  transition_type: 'alert recovery'
+                }
+              }
+            }
+          }
+        }
+      } as unknown as v2.EventResponse
+
+      const transition = formatMonitorTransition(event)
+
+      expect(transition).not.toBeNull()
+      expect(transition).toMatchObject({
+        timestamp: '2026-05-13T23:24:00.000Z',
+        monitorId: 282774192,
+        monitorName: '[DO-1712] Pod readiness production',
+        fromState: 'Alert',
+        toState: 'OK',
+        transitionType: 'alert recovery',
+        group: 'kube_namespace:production',
+        eventId: 'evt-ap'
+      })
+    })
+
     it('uses numeric timestamp at the inner attributes when the outer Date is absent', () => {
       const event = {
         id: 'evt-6',

--- a/tests/tools/monitors-helpers.test.ts
+++ b/tests/tools/monitors-helpers.test.ts
@@ -863,6 +863,19 @@ describe('MonitorConfigSchema — top-level rejection', () => {
       })
       expect(emptyGroup).not.toContain('@monitor.groups')
     })
+
+    it('escapes backslashes and double quotes inside a group value', () => {
+      // A group name containing a literal double quote must not break out of
+      // the quoted clause. Backslashes are escaped first so that subsequent
+      // quote-escaping does not produce dangling backslashes.
+      const query = buildMonitorHistoryQuery({
+        monitorId: 42,
+        group: 'pod_name:weird"name\\with\\slashes'
+      })
+      expect(query).toBe(
+        'source:alert @monitor.id:42 @monitor.groups:"pod_name:weird\\"name\\\\with\\\\slashes"'
+      )
+    })
   })
 
   describe('formatMonitorTransition', () => {

--- a/tests/tools/monitors-history.test.ts
+++ b/tests/tools/monitors-history.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Behavior tests for `monitors action=history` — see design.md
+ * "Testing strategy > Unit tests" (13 enumerated cases) for the source list.
+ *
+ * The implementation under test is `historyMonitor` (orchestration) and the
+ * `history` case in `registerMonitorsTool` (handler wiring). Fixtures and the
+ * msw dispatch handler land in Task 1; helpers in Task 2; orchestration in
+ * Task 3; handler wiring in Task 4. This file consumes all of those.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { v1, v2 } from '@datadog/datadog-api-client'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { http, HttpResponse } from 'msw'
+import {
+  server,
+  endpoints,
+  errorResponse,
+  jsonResponse,
+  monitorHistoryEventsSearchHandler
+} from '../helpers/msw.js'
+import { createMockConfig } from '../helpers/mock.js'
+import { monitorHistoryFixtures } from '../helpers/fixtures.js'
+import { historyMonitor, registerMonitorsTool } from '../../src/tools/monitors.js'
+import type { LimitsConfig } from '../../src/config/schema.js'
+
+const defaultLimits: LimitsConfig = {
+  defaultLimit: 50,
+  defaultLogLines: 200,
+  defaultMetricDataPoints: 1000,
+  defaultTimeRangeHours: 24
+}
+
+const defaultSite = 'datadoghq.com'
+
+describe('Monitors Tool — action=history', () => {
+  let eventsApi: v2.EventsApi
+
+  beforeEach(() => {
+    const config = createMockConfig()
+    eventsApi = new v2.EventsApi(config)
+  })
+
+  describe('historyMonitor (orchestration)', () => {
+    it('case 1 — happy path: returns the single alert transition for monitor 1001 (alertOnly fixture)', async () => {
+      server.use(monitorHistoryEventsSearchHandler())
+
+      const result = await historyMonitor(eventsApi, 1001, {}, defaultLimits, defaultSite)
+
+      expect(result.count).toBe(1)
+      expect(result.transitions).toHaveLength(1)
+      expect(result.transitions[0]).toMatchObject({
+        monitorId: 1001,
+        monitorName: '[DO-1712] Pod readiness production',
+        fromState: 'OK',
+        toState: 'Alert',
+        transitionType: 'alert',
+        eventId: 'evt-mh-1001-001'
+      })
+      expect(result.transitions[0]?.group).toBe('kube_namespace:production,pod_name:foo')
+      expect(result.meta.count).toBe(1)
+      expect(result.meta.totalFetched).toBe(1)
+      expect(result.meta.truncated).toBe(false)
+      expect(result.meta.monitorId).toBe(1001)
+      expect(result.meta.datadog_url).toContain('app.datadoghq.com')
+    })
+
+    it('case 2 — empty result: returns count 0 for monitor 1005 (empty fixture) with no error', async () => {
+      server.use(monitorHistoryEventsSearchHandler())
+
+      const result = await historyMonitor(eventsApi, 1005, {}, defaultLimits, defaultSite)
+
+      expect(result.count).toBe(0)
+      expect(result.transitions).toEqual([])
+      expect(result.meta.count).toBe(0)
+      expect(result.meta.totalFetched).toBe(0)
+      expect(result.meta.truncated).toBe(false)
+    })
+
+    it('case 3 — dynamic-title regression (issue #53): unique titles per event do NOT collapse to count 1; filtered transition_type query returns count 2', async () => {
+      // Issue #53: an SLO burn-rate monitor emits events whose titles vary every
+      // evaluation ("burn rates of 6.01 and 12.01"). A stale dedup-by-title
+      // implementation would collapse all of these to a single bucket. The
+      // correct behavior is to count each event as its own transition.
+      //
+      // The dispatch in tests/helpers/msw.ts returns the dynamicTitle fixture
+      // (5 events: 3 'alert' + 2 'alert recovery') regardless of the request
+      // filter. To emulate Datadog's server-side filtering of
+      // @monitor.transition.transition_type, we wire a test-local handler that
+      // narrows the fixture to the requested transition types.
+      server.use(
+        http.post(endpoints.searchEvents, async ({ request }) => {
+          const body = (await request.json()) as { filter?: { query?: string } }
+          const sentQuery = body.filter?.query ?? ''
+          expect(sentQuery).toContain('@monitor.id:1003')
+          // Pull the transition_type values out of the (alert recovery OR ...) clause.
+          const typesMatch = /@monitor\.transition\.transition_type:\(([^)]+)\)/.exec(sentQuery)
+          const requested = typesMatch
+            ? typesMatch[1].split(' OR ').map((s) => s.trim().replace(/^"|"$/g, ''))
+            : null
+
+          const filtered = monitorHistoryFixtures.dynamicTitle.data.filter((event) => {
+            if (!requested) return true
+            const t = event.attributes.attributes.monitor.transition.transition_type
+            return requested.includes(t)
+          })
+
+          return jsonResponse({
+            data: filtered,
+            meta: { page: { after: null } }
+          })
+        })
+      )
+
+      const result = await historyMonitor(
+        eventsApi,
+        1003,
+        { transitionType: ['alert recovery'] },
+        defaultLimits,
+        defaultSite
+      )
+
+      // Two 'alert recovery' events in the dynamicTitle fixture; titles differ
+      // for each but each one must surface as its own transition record.
+      expect(result.count).toBe(2)
+      expect(result.transitions).toHaveLength(2)
+      for (const transition of result.transitions) {
+        expect(transition.transitionType).toBe('alert recovery')
+        expect(transition.monitorId).toBe(1003)
+      }
+      // Each event has a unique title; verify the projection still produces
+      // distinct transition records (i.e. no title-based dedup is happening).
+      const eventIds = result.transitions.map((t) => t.eventId)
+      expect(new Set(eventIds).size).toBe(eventIds.length)
+    })
+
+    it('case 4 — multi-alert + group filter: monitor 1002 with group "host:web-01" emits the group clause in the assembled query', async () => {
+      // Capture the request body so we can assert the query string composition,
+      // and inline the same dispatch the shared handler uses for monitor 1002.
+      const requestBodies: Array<{ filter?: { query?: string } }> = []
+      server.use(
+        http.post(endpoints.searchEvents, async ({ request }) => {
+          const body = (await request.json()) as {
+            filter?: { query?: string }
+            page?: { cursor?: string }
+          }
+          requestBodies.push(body)
+          return jsonResponse(monitorHistoryFixtures.mixed)
+        })
+      )
+
+      const result = await historyMonitor(
+        eventsApi,
+        1002,
+        { group: 'host:web-01' },
+        defaultLimits,
+        defaultSite
+      )
+
+      expect(requestBodies.length).toBeGreaterThan(0)
+      const sentQuery = requestBodies[0]?.filter?.query ?? ''
+      expect(sentQuery).toContain('source:alert')
+      expect(sentQuery).toContain('@monitor.id:1002')
+      expect(sentQuery).toContain('@monitor.groups:"host:web-01"')
+      // Default transitionType filter is also propagated to the wire.
+      expect(sentQuery).toContain('@monitor.transition.transition_type:(alert OR "alert recovery")')
+      expect(result.meta.query).toBe(sentQuery)
+      expect(result.meta.group).toBe('host:web-01')
+      // The fixture's 4 events all carry a `monitor.transition` block, so each
+      // surfaces as a transition record on the client side; Datadog applies
+      // the transition_type filter server-side in production.
+      expect(result.count).toBe(4)
+      expect(result.transitions).toHaveLength(4)
+    })
+
+    it('case 5 — default time range: when from/to are omitted, meta.from and meta.to span limits.defaultTimeRangeHours', async () => {
+      server.use(monitorHistoryEventsSearchHandler())
+
+      const before = Date.now()
+      const result = await historyMonitor(eventsApi, 1001, {}, defaultLimits, defaultSite)
+      const after = Date.now()
+
+      // ISO 8601 sanity
+      expect(result.meta.from).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+      expect(result.meta.to).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+
+      const fromMs = new Date(result.meta.from).getTime()
+      const toMs = new Date(result.meta.to).getTime()
+      const expectedDeltaMs = defaultLimits.defaultTimeRangeHours * 3600 * 1000
+
+      // Delta should equal defaultTimeRangeHours within a few seconds (allows
+      // for time elapsed between hoursAgo() and now() during the call).
+      const actualDeltaMs = toMs - fromMs
+      expect(actualDeltaMs).toBeGreaterThanOrEqual(expectedDeltaMs - 5000)
+      expect(actualDeltaMs).toBeLessThanOrEqual(expectedDeltaMs + 5000)
+
+      // The `to` bound must fall within the window of this test invocation
+      // (parseTime resolves it at call time).
+      expect(toMs).toBeGreaterThanOrEqual(before - 1000)
+      expect(toMs).toBeLessThanOrEqual(after + 1000)
+    })
+
+    it('case 6 — relative time input: from: "7d" is parsed and the resulting window is ~7 days', async () => {
+      server.use(monitorHistoryEventsSearchHandler())
+
+      const result = await historyMonitor(
+        eventsApi,
+        1001,
+        { from: '7d' },
+        defaultLimits,
+        defaultSite
+      )
+
+      const fromMs = new Date(result.meta.from).getTime()
+      const toMs = new Date(result.meta.to).getTime()
+      const deltaMs = toMs - fromMs
+      const sevenDaysMs = 7 * 24 * 3600 * 1000
+
+      expect(deltaMs).toBeGreaterThanOrEqual(sevenDaysMs - 5000)
+      expect(deltaMs).toBeLessThanOrEqual(sevenDaysMs + 5000)
+    })
+
+    it('case 7 — epoch time input: from: "1700000000" is parsed as a Unix timestamp', async () => {
+      server.use(monitorHistoryEventsSearchHandler())
+
+      const result = await historyMonitor(
+        eventsApi,
+        1001,
+        { from: '1700000000' },
+        defaultLimits,
+        defaultSite
+      )
+
+      const fromMs = new Date(result.meta.from).getTime()
+      expect(fromMs).toBe(1700000000 * 1000)
+    })
+
+    it('case 8 — ISO time input: from: "2026-05-01T00:00:00Z" is parsed as ISO 8601', async () => {
+      server.use(monitorHistoryEventsSearchHandler())
+
+      const result = await historyMonitor(
+        eventsApi,
+        1001,
+        { from: '2026-05-01T00:00:00Z', to: '2026-05-08T00:00:00Z' },
+        defaultLimits,
+        defaultSite
+      )
+
+      expect(new Date(result.meta.from).getTime()).toBe(Date.parse('2026-05-01T00:00:00Z'))
+      expect(new Date(result.meta.to).getTime()).toBe(Date.parse('2026-05-08T00:00:00Z'))
+    })
+
+    it('case 12 — pagination across two pages: monitor 1004 returns all transitions from page1 and page2', async () => {
+      server.use(monitorHistoryEventsSearchHandler())
+
+      const result = await historyMonitor(eventsApi, 1004, {}, defaultLimits, defaultSite)
+
+      // multiPage fixture: page1 has 2 events (1 alert + 1 alert recovery),
+      // page2 has 1 event (1 alert). All are real transitions → count === 3.
+      expect(result.count).toBe(3)
+      expect(result.transitions).toHaveLength(3)
+      expect(result.meta.totalFetched).toBe(3)
+      expect(result.meta.truncated).toBe(false)
+
+      const eventIds = result.transitions.map((t) => t.eventId)
+      expect(eventIds).toEqual(
+        expect.arrayContaining(['evt-mh-1004-001', 'evt-mh-1004-002', 'evt-mh-1004-003'])
+      )
+    })
+
+    it('case 13 — truncation: when the broker returns events indefinitely, the loop caps at maxEventsToProcess and sets meta.truncated', async () => {
+      // Custom handler: every page returns 1000 events with a never-null cursor.
+      // historyMonitor caps at maxEventsToProcess = 10000 (10 pages of 1000),
+      // sets meta.truncated = true, and returns transitions.length <= 10000.
+      let pageIndex = 0
+      server.use(
+        http.post(endpoints.searchEvents, async () => {
+          pageIndex++
+          const data = Array.from({ length: 1000 }, (_, i) => ({
+            id: `evt-trunc-${pageIndex}-${i}`,
+            type: 'event',
+            attributes: {
+              timestamp: '2026-05-13T10:00:00.000Z',
+              tags: ['source:alert', 'monitor_id:99999'],
+              attributes: {
+                title: `[Triggered] truncation event ${pageIndex}-${i}`,
+                monitor: {
+                  id: 99999,
+                  name: 'Truncation monitor',
+                  groups: ['env:test'],
+                  transition: {
+                    source_state: 'OK',
+                    destination_state: 'Alert',
+                    transition_type: 'alert'
+                  }
+                }
+              }
+            }
+          }))
+          return HttpResponse.json({
+            data,
+            meta: { page: { after: `cursor-${pageIndex + 1}` } }
+          })
+        })
+      )
+
+      const result = await historyMonitor(eventsApi, 99999, {}, defaultLimits, defaultSite)
+
+      expect(result.meta.truncated).toBe(true)
+      // historyMonitor's cap = 10000 events / 100 pages, whichever comes first.
+      // With 1000 events per page, the event-count cap fires at 10 pages.
+      expect(result.transitions.length).toBeLessThanOrEqual(10000)
+      expect(result.transitions.length).toBeGreaterThan(0)
+      expect(result.meta.totalFetched).toBeGreaterThanOrEqual(10000)
+    })
+  })
+
+  describe('registerMonitorsTool handler dispatch (action=history)', () => {
+    type ToolHandler = (params: Record<string, unknown>) => Promise<{
+      content: Array<{ type: string; text: string }>
+    }>
+
+    function buildMockServer(): { mockServer: McpServer; getHandler: () => ToolHandler } {
+      let captured: ToolHandler | undefined
+      const mockServer = {
+        tool: vi.fn((_name: string, _description: string, _schema: unknown, handler: unknown) => {
+          captured = handler as ToolHandler
+        })
+      } as unknown as McpServer
+      const getHandler = (): ToolHandler => {
+        if (!captured) {
+          throw new Error('Tool handler was not registered')
+        }
+        return captured
+      }
+      return { mockServer, getHandler }
+    }
+
+    function buildMonitorsApi(): v1.MonitorsApi {
+      return new v1.MonitorsApi(createMockConfig())
+    }
+
+    it('case 9 — missing id: throws InvalidParams when id is omitted on action=history', async () => {
+      server.use(monitorHistoryEventsSearchHandler())
+      const { mockServer, getHandler } = buildMockServer()
+      registerMonitorsTool(
+        mockServer,
+        buildMonitorsApi(),
+        eventsApi,
+        defaultLimits,
+        false,
+        defaultSite
+      )
+      const handler = getHandler()
+
+      // requireParam throws an McpError; handleDatadogError rethrows it.
+      await expect(handler({ action: 'history' })).rejects.toThrow(/required.*history/i)
+    })
+
+    it('case 10 — non-numeric id: throws "Invalid monitor ID: ..." on action=history', async () => {
+      server.use(monitorHistoryEventsSearchHandler())
+      const { mockServer, getHandler } = buildMockServer()
+      registerMonitorsTool(
+        mockServer,
+        buildMonitorsApi(),
+        eventsApi,
+        defaultLimits,
+        false,
+        defaultSite
+      )
+      const handler = getHandler()
+
+      await expect(handler({ action: 'history', id: 'not-a-number' })).rejects.toThrow(
+        /Invalid monitor ID: not-a-number/
+      )
+    })
+
+    it('case 11 — read-only success: action=history succeeds when readOnly: true is set on the server', async () => {
+      server.use(monitorHistoryEventsSearchHandler())
+      const { mockServer, getHandler } = buildMockServer()
+      registerMonitorsTool(
+        mockServer,
+        buildMonitorsApi(),
+        eventsApi,
+        defaultLimits,
+        true,
+        defaultSite
+      )
+      const handler = getHandler()
+
+      // The action must NOT throw the read-only guard error.
+      const result = await handler({ action: 'history', id: '1001' })
+
+      const text = result.content[0]?.text ?? ''
+      expect(text).not.toMatch(/not allowed in read-only mode/i)
+      // Sanity: payload reflects the alertOnly fixture.
+      const parsed = JSON.parse(text) as { count: number; transitions: Array<unknown> }
+      expect(parsed.count).toBe(1)
+      expect(parsed.transitions).toHaveLength(1)
+    })
+  })
+
+  describe('error mapping (defensive)', () => {
+    it('Datadog 401 is mapped to a 401-coded rejection by handleDatadogError', async () => {
+      server.use(http.post(endpoints.searchEvents, () => errorResponse(401, 'Invalid API key')))
+
+      await expect(
+        historyMonitor(eventsApi, 1001, {}, defaultLimits, defaultSite)
+      ).rejects.toMatchObject({ code: 401 })
+    })
+  })
+})


### PR DESCRIPTION
Implements `monitor-state-history` spec — closes #53.

## Summary

New **`monitors action=history`** action returns the real state transitions for one monitor over a time window, filtered by `source:alert @monitor.transition.transition_type:(alert OR "alert recovery")` so it excludes renotify events. Default count semantics: `count = transitions.length` = real fires + recoveries.

Plus an additive **`events` `transitionType` filter** so callers using the events tool directly can apply the same transition-type filter and get the same count semantics.

## Live validation (Task 10)

Probed against monitor 282774192 (same monitor from the design investigation) over the last 7 days:

| Query | Events |
|---|---|
| Raw `source:alert @monitor.id:282774192` | **130** (renotify-inflated) |
| `source:alert ... @monitor.transition.transition_type:(alert OR "alert recovery")` | **46** (39 alerts + 7 recoveries) |

**Delta: 84 renotify/duplicate events filtered out.** The issue-#53 over-count problem is resolved at the API layer.

The spec's investigation log captured 38 transitions over a 7-day window 9 days ago — the monitor has continued firing since, so the absolute count differs but the **mechanism is verified**.

## Architecture

- `formatMonitorTransition(event)` — projects v2 events to `MonitorTransition` typed records (handles SDK `additionalProperties` quirk)
- `buildMonitorHistoryQuery({monitorId, transitionType?, group?})` — composes the query string with proper quoting for multi-word values like `"alert recovery"`
- `historyMonitor(eventsApi, monitorId, params, limits, site)` — paginated orchestration (maxPages=100, maxEventsToProcess=10000) with truncation flag
- `monitors action=history` dispatch case in `registerMonitorsTool` (id required, transitionType + group optional)
- `events.transitionType` input filter threaded through search/aggregate/top/timeseries/incidents — backward compatible (additive)
- Tool descriptions on both `monitors` and `events` updated to disclose that `source:alert` includes renotifies and point callers to `history` for fires-only counts

## Tests

- 14 new tests in `tests/tools/monitors-history.test.ts` — covers happy path, empty result, dynamic-title regression (issue #53 case), group filter, default+relative+epoch+ISO time inputs, missing/non-numeric id, read-only success, two-page pagination, truncation at 10000.
- 13 new helper tests in `tests/tools/monitors-helpers.test.ts` — covers `formatMonitorTransition` + `buildMonitorHistoryQuery` quoting/default-clause/group/empty-array.
- 5 new tests in `tests/tools/events.test.ts` — covers transitionType clause appending + byte-equivalence when omitted.
- 5 new msw fixtures (`monitorHistoryFixtures`) with dynamic-title regression coverage.
- Full suite: **1044/1044 pass** across 64 files (was 1031 before this spec — net +13).

## Notable implementation finding

The Datadog SDK's `ObjectSerializer` moves unknown event-attribute keys into `monitor.additionalProperties` post-deserialization. `formatMonitorTransition` reads `transition` from BOTH `monitor.transition` and `monitor.additionalProperties.transition` to handle both raw HTTP responses and SDK-deserialized objects.

## Test plan

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm test -- --run` (1044/1044)
- [x] Live API validation (Task 10) — see "Live validation" above