### PR TITLE
feat: DX improvements - dry_run, histogram, preview, timezone, diagnostics, rollup meta (#49 large items)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,10 @@ When running with `--transport=http`:
 | `monitors` | list | Alerting | List monitors with optional filters | `monitors_read` |
 | `monitors` | get | Alerting | Get monitor by ID | `monitors_read` |
 | `monitors` | search | Alerting | Search monitors by query | `monitors_read` |
-| `monitors` | create | Alerting | Create a new monitor; `config` is validated against a typed schema covering documented options (notifyNoData, renotifyInterval, thresholds, …) — unknown keys surface in `warnings` | `monitors_write` |
+| `monitors` | create | Alerting | Create a new monitor; `config` is validated against a typed schema covering documented options (notifyNoData, renotifyInterval, thresholds, …) — unknown keys surface in `warnings`. Pass `dry_run: true` to validate without creating (uses `/api/v1/monitor/validate`, allowed in read-only mode). | `monitors_write` |
 | `monitors` | update | Alerting | Update an existing monitor; same validated schema as `create`; partial configs accepted; validation errors short-circuit before any HTTP call as `EINVALID_MONITOR_CONFIG:` | `monitors_write` |
+| `monitors` | preview | Alerting | Render a monitor template (inline `message` or by `monitor_id`/`id`) with optional `context` of variables and conditionals. Returns `{rendered, variablesUsed, variablesMissing, conditionalsResolved}`. Supports Datadog Mustache subset: variable substitution + six documented conditionals (`is_alert`, `is_warning`, `is_no_data`, `is_recovery`, `is_alert_to_warning`, `is_warning_to_alert`); `{{#each}}`/partials throw `EUNSUPPORTED_TEMPLATE_SYNTAX`. Read-only. | `monitors_read` |
+| `monitors` | test_notification | Alerting | **Known limitation**: returns `ENOT_SUPPORTED` — Datadog has no public REST endpoint for triggering a test notification. Documentation pointer in response. | n/a |
 | `monitors` | delete | Alerting | Delete a monitor | `monitors_write` |
 | `monitors` | mute | Alerting | Mute a monitor | `monitors_write` |
 | `monitors` | unmute | Alerting | Unmute a monitor | `monitors_write` |
@@ -145,7 +147,7 @@ When running with `--transport=http`:
 | `logs_archives` | list, get | Logs Config | Inspect log archives (S3 / GCS / Azure destinations); per-provider credential fields are forwarded unchanged | `logs_read_archives` |
 | `logs_archives` | create, update, delete, reorder | Logs Config | Manage archive destinations; `destination.type` validated against `s3 | gcs | azure_storage` before SDK call | `logs_write_archives` |
 | `logs_archives` | get_order | Logs Config | Read archive evaluation order | `logs_read_archives` |
-| `metrics` | query | Metrics | Query timeseries data | `metrics_read`, `timeseries_query` |
+| `metrics` | query | Metrics | Query timeseries data. Response `meta` now includes `rollupRequested` (parsed from `rollup(method, seconds)` in the query, with `methodInferred` flag), `rollupEffective` (interval derived from returned pointlist intervals + deduped `intervalsObserved` for multi-series), and `rollupOverridden: boolean` so callers can detect when Datadog silently downsampled. | `metrics_read`, `timeseries_query` |
 | `metrics` | search | Metrics | Search for metrics by name | `metrics_read` |
 | `metrics` | list | Metrics | List active metrics | `metrics_read` |
 | `metrics` | metadata | Metrics | Get metric metadata | `metrics_read` |
@@ -155,7 +157,8 @@ When running with `--transport=http`:
 | `events` | list | Events | List events | `events_read` |
 | `events` | get | Events | Get event by ID | `events_read` |
 | `events` | create | Events | Create an event | `events_read` |
-| `events` | search | Events | Search events with v2 API and cursor pagination. Optional `transitionType` filter (e.g. `["alert","alert recovery"]`) restricts to monitor state-transition events — without it, `source:alert` includes renotifies. For monitor-specific fires use `monitors action=history`. | `events_read` |
+| `events` | search | Events | Search events with v2 API and cursor pagination. Optional `transitionType` filter (e.g. `["alert","alert recovery"]`) restricts to monitor state-transition events — without it, `source:alert` includes renotifies. For monitor-specific fires use `monitors action=history`. Optional `timezone` adds `*Local` ISO 8601 siblings to every timestamp. Zero-result responses include a `diagnostics` array hinting at the cause (`UNINDEXED_TAG_PREFIX`, `NARROW_TIME_RANGE`, `RESTRICTIVE_SOURCE_FILTER`). | `events_read` |
+| `events` | histogram | Events | Server-side bucketing of events by `hour_of_day`, `day_of_week`, or `day_of_month` in an IANA `timezone` (DST-safe via `Intl.DateTimeFormat`). Cursor-paginates the underlying search; cap at `limits.maxEventsForHistogram` (default 5000, `MCP_MAX_EVENTS_HISTOGRAM` env var). When the cap is hit, returns `bucketCountIncomplete: true` and `nextCursor` for continuation. | `events_read` |
 | `events` | aggregate | Events | Client-side aggregation by monitor_name, source, etc. | `events_read` |
 | `events` | top | Events | Top N event groups by count with generic groupBy support (deployments, configs, alerts, etc.). Groups without context tags are included as "no_context" | `events_read` |
 | `events` | timeseries | Events | Time-bucketed alert trends (hourly/daily counts) | `events_read` |

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -107,7 +107,8 @@ export function loadConfig(): Config {
       defaultLimit: Number.parseInt(process.env.MCP_DEFAULT_LIMIT ?? '50', 10),
       defaultLogLines: Number.parseInt(process.env.MCP_DEFAULT_LOG_LINES ?? '200', 10),
       defaultMetricDataPoints: Number.parseInt(process.env.MCP_DEFAULT_METRIC_POINTS ?? '1000', 10),
-      defaultTimeRangeHours: Number.parseInt(process.env.MCP_DEFAULT_TIME_RANGE ?? '24', 10)
+      defaultTimeRangeHours: Number.parseInt(process.env.MCP_DEFAULT_TIME_RANGE ?? '24', 10),
+      maxEventsForHistogram: Number.parseInt(process.env.MCP_MAX_EVENTS_HISTOGRAM ?? '5000', 10)
     },
     features: {
       readOnly: args.booleans.has('read-only') || process.env.MCP_READ_ONLY === 'true',

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -46,7 +46,12 @@ export const configSchema = z.object({
       defaultLimit: z.number().default(50), // Fallback when AI doesn't specify limit
       defaultLogLines: z.number().default(200), // Fallback when AI doesn't specify log limit
       defaultMetricDataPoints: z.number().default(1000), // Fallback for timeseries data points
-      defaultTimeRangeHours: z.number().default(24)
+      defaultTimeRangeHours: z.number().default(24),
+      // Maximum events scanned by the `events.histogram` action before returning a
+      // partial result with `bucketCountIncomplete: true` and `nextCursor`.
+      // Bounds latency on bucketed queries while still giving callers a path to
+      // continue scanning if they want a fully complete histogram.
+      maxEventsForHistogram: z.number().default(5000)
     })
     .default({}),
   features: z

--- a/src/schema/events.ts
+++ b/src/schema/events.ts
@@ -1,0 +1,20 @@
+/**
+ * Events schema definitions
+ *
+ * Enumerates the diagnostic codes that `events.search` can attach to a
+ * zero-result response. Agents can introspect this list via the `schema` tool
+ * so they know which diagnostics to expect and how to remediate them.
+ *
+ * Docs: https://docs.datadoghq.com/service_management/events/
+ */
+
+export const events = {
+  /**
+   * Diagnostic codes emitted on zero-result `events.search` responses.
+   * Each code is also documented inline in `src/tools/events.ts` next to the
+   * heuristic that produces it.
+   */
+  diagnosticCodes: ['UNINDEXED_TAG_PREFIX', 'NARROW_TIME_RANGE', 'RESTRICTIVE_SOURCE_FILTER'],
+
+  docsUrl: 'https://docs.datadoghq.com/api/latest/events/'
+} as const

--- a/src/schema/index.ts
+++ b/src/schema/index.ts
@@ -7,11 +7,12 @@
  */
 
 import { dashboards } from './dashboards.js'
+import { events } from './events.js'
 import { metrics } from './metrics.js'
 import { monitors } from './monitors.js'
 import { slos } from './slos.js'
 
-export const schemas = { dashboards, metrics, monitors, slos } as const
+export const schemas = { dashboards, events, metrics, monitors, slos } as const
 
 export type SchemaResource = keyof typeof schemas
 export const schemaResources = Object.keys(schemas) as SchemaResource[]

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -185,6 +185,12 @@ interface TimeseriesBucket {
   timestampMs: number
   counts: Record<string, number>
   total: number
+  /**
+   * ISO 8601 string with offset rendered in the requested IANA timezone.
+   * Present ONLY when the caller passed a `timezone` parameter (Requirement 4).
+   * Omitting `timezone` produces a response shape byte-identical to today.
+   */
+  timestampLocal?: string
 }
 
 // Incident format (Phase 2 - deduplicated events)
@@ -1442,10 +1448,17 @@ export async function timeseriesEventsV2(
     interval?: string
     limit?: number
     transitionType?: string[]
+    timezone?: string
   },
   limits: LimitsConfig,
   site: string
 ) {
+  // Requirement 4: validate timezone BEFORE any Datadog call so an invalid zone
+  // never burns an API request quota and surfaces a stable EINVALID_TIMEZONE.
+  if (params.timezone !== undefined) {
+    validateIanaZone(params.timezone)
+  }
+
   const defaultFrom = hoursAgo(limits.defaultTimeRangeHours)
   const defaultTo = now()
 
@@ -1517,6 +1530,7 @@ export async function timeseriesEventsV2(
   }
 
   // Convert to sorted array of buckets
+  const tz = params.timezone
   const sortedBuckets = [...timeBuckets.entries()]
     .sort((a, b) => a[0] - b[0])
     .map(([bucketTs, groupCounts]) => {
@@ -1526,12 +1540,18 @@ export async function timeseriesEventsV2(
         counts[key] = count
         total += count
       }
-      return {
+      const bucket: TimeseriesBucket = {
         timestamp: new Date(bucketTs).toISOString(),
         timestampMs: bucketTs,
         counts,
         total
-      } satisfies TimeseriesBucket
+      }
+      // Requirement 4: annotate bucket timestamps with a sibling timestampLocal
+      // ONLY when the caller supplied a timezone — preserves byte-identical legacy shape.
+      if (tz !== undefined) {
+        bucket.timestampLocal = formatLocal(bucketTs, tz)
+      }
+      return bucket
     })
 
   // Apply limit to buckets if specified
@@ -2062,7 +2082,8 @@ histogram: Bucket events by local hour_of_day / day_of_week / day_of_month in th
                   groupBy,
                   interval,
                   limit,
-                  transitionType
+                  transitionType,
+                  timezone
                 },
                 limits,
                 site

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -706,9 +706,8 @@ export function computeDiagnostics(input: {
   const diagnostics: EventsDiagnostic[] = []
 
   const query = input.query ?? ''
-  // NOSONAR S5852: anchored alternation, no nested quantifiers, input is bounded user query string
   const queryHasSourceAlert =
-    /(^|\s|\()source:alert(\s|\)|$)/.test(query) ||
+    /(^|\s|\()source:alert(\s|\)|$)/.test(query) || // NOSONAR S5852: anchored alternation, bounded input, no nested quantifiers
     (input.sources?.includes('alert') ?? false) ||
     (input.tags?.includes('source:alert') ?? false)
 

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -1312,11 +1312,12 @@ export async function topEventsV2(
   )
 
   // Step 2: Group by specified fields
+  type GroupValue = string | number
   const eventGroups = new Map<
     string,
     {
       groupKey: string
-      groupValues: Record<string, any>
+      groupValues: Record<string, GroupValue>
       message: string
       events: EventSummaryV2[]
     }
@@ -1324,11 +1325,11 @@ export async function topEventsV2(
 
   for (const event of result.events) {
     // Extract values for each groupBy field
-    const groupValues: Record<string, any> = {}
+    const groupValues: Record<string, GroupValue> = {}
     const keyParts: string[] = []
 
     for (const field of groupByFields) {
-      let value: any
+      let value: GroupValue
       if (field === 'monitor_id') {
         value = event.monitorId ?? 0
       } else if (field === 'monitor_name') {
@@ -1336,7 +1337,7 @@ export async function topEventsV2(
       } else {
         // Extract from tags (format: field:value)
         const tag = event.tags.find((t) => t.startsWith(`${field}:`))
-        value = tag ? tag.split(':', 2)[1] : 'unknown'
+        value = tag ? (tag.split(':', 2)[1] ?? 'unknown') : 'unknown'
       }
       groupValues[field] = value
       keyParts.push(`${field}:${value}`)

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -9,7 +9,8 @@ import {
   bucketHourOfDay,
   bucketDayOfWeek,
   bucketDayOfMonth,
-  validateIanaZone
+  validateIanaZone,
+  formatLocal
 } from '../utils/timezone.js'
 import type { LimitsConfig } from '../config/schema.js'
 
@@ -110,7 +111,10 @@ const InputSchema = {
     .string()
     .optional()
     .describe(
-      'IANA timezone for histogram bucketing (e.g. "UTC", "Europe/Paris"). DST-safe. Default: UTC.'
+      'Optional IANA timezone (e.g. "UTC", "Europe/Paris"). DST-safe. ' +
+        'For histogram: controls hour/day bucketing (default: UTC). ' +
+        'For search/aggregate/top/incidents read actions: adds sibling *Local ISO 8601 ' +
+        'strings (e.g. timestampLocal) next to existing timestamps. Omit for byte-identical legacy shape.'
     )
 }
 
@@ -145,6 +149,27 @@ interface EventSummaryV2 {
     scope: string
     priority?: string
   }
+  /**
+   * ISO 8601 string with offset rendered in the requested IANA timezone.
+   * Present ONLY when the caller passed a `timezone` parameter (Requirement 4).
+   * Omitting `timezone` produces a response shape byte-identical to today.
+   */
+  timestampLocal?: string
+}
+
+/**
+ * Annotate a single event's `timestamp` with a sibling `timestampLocal` ISO 8601
+ * string in the requested IANA timezone (Requirement 4).
+ *
+ * Returns a shallow-copied event; the original is left untouched. Events with a
+ * missing or unparseable timestamp are returned unchanged — better to surface a
+ * silent skip than to crash the whole search on one bad row.
+ */
+function annotateEventTimezone(event: EventSummaryV2, tz: string): EventSummaryV2 {
+  if (!event.timestamp) return event
+  const ms = new Date(event.timestamp).getTime()
+  if (!Number.isFinite(ms)) return event
+  return { ...event, timestampLocal: formatLocal(ms, tz) }
 }
 
 // Aggregation bucket format
@@ -172,6 +197,10 @@ interface IncidentEvent {
   recoveredAt?: string
   duration?: string
   sample: EventSummaryV2
+  // Requirement 4: present only when caller supplied `timezone`.
+  firstTriggerLocal?: string
+  lastTriggerLocal?: string
+  recoveredAtLocal?: string
 }
 
 // Enriched event with monitor metadata (Phase 3)
@@ -796,10 +825,17 @@ export async function searchEventsV2(
     limit?: number
     cursor?: string
     transitionType?: string[]
+    timezone?: string
   },
   limits: LimitsConfig,
   site: string
 ) {
+  // Requirement 4: validate timezone BEFORE any Datadog call so an invalid zone
+  // never burns an API request quota and surfaces a stable EINVALID_TIMEZONE.
+  if (params.timezone !== undefined) {
+    validateIanaZone(params.timezone)
+  }
+
   const defaultFrom = hoursAgo(limits.defaultTimeRangeHours)
   const defaultTo = now()
 
@@ -835,7 +871,12 @@ export async function searchEventsV2(
 
   const response = await api.searchEvents({ body })
 
-  const events = (response.data ?? []).map(formatEventV2)
+  const rawEvents = (response.data ?? []).map(formatEventV2)
+  // Requirement 4: annotate only when timezone is supplied — opt-in shape change.
+  const events =
+    params.timezone !== undefined
+      ? rawEvents.map((e) => annotateEventTimezone(e, params.timezone as string))
+      : rawEvents
   const nextCursor = response.meta?.page?.after
 
   const baseResult = {
@@ -1089,10 +1130,16 @@ export async function aggregateEventsV2(
     groupBy?: string[]
     limit?: number
     transitionType?: string[]
+    timezone?: string
   },
   limits: LimitsConfig,
   site: string
 ) {
+  // Requirement 4: validate timezone BEFORE any Datadog call.
+  if (params.timezone !== undefined) {
+    validateIanaZone(params.timezone)
+  }
+
   const counts = new Map<string, { count: number; sample: EventSummaryV2 }>()
 
   const defaultFrom = hoursAgo(limits.defaultTimeRangeHours)
@@ -1172,7 +1219,11 @@ export async function aggregateEventsV2(
   const buckets: AggregationBucket[] = sorted.map(([key, data]) => ({
     key,
     count: data.count,
-    sample: data.sample
+    // Requirement 4: annotate sample timestamps only when timezone is supplied.
+    sample:
+      params.timezone !== undefined
+        ? annotateEventTimezone(data.sample, params.timezone)
+        : data.sample
   }))
 
   return {
@@ -1208,10 +1259,20 @@ export async function topEventsV2(
     contextTags?: string[]
     maxEvents?: number
     transitionType?: string[]
+    timezone?: string
   },
   limits: LimitsConfig,
   site: string
 ) {
+  // Requirement 4: validate timezone BEFORE any Datadog call. The current `top`
+  // response shape exposes grouped counts and context breakdown — no per-event
+  // timestamps — so annotation is a no-op on the output today; threading the
+  // param ensures invalid zones still fail fast and reserves space for future
+  // sample fields without a contract break.
+  if (params.timezone !== undefined) {
+    validateIanaZone(params.timezone)
+  }
+
   // Validate contextTags if provided
   if (params.contextTags !== undefined) {
     if (!Array.isArray(params.contextTags)) {
@@ -1510,10 +1571,16 @@ export async function incidentsEventsV2(
     dedupeWindow?: string
     limit?: number
     transitionType?: string[]
+    timezone?: string
   },
   limits: LimitsConfig,
   site: string
 ) {
+  // Requirement 4: validate timezone BEFORE any Datadog call.
+  if (params.timezone !== undefined) {
+    validateIanaZone(params.timezone)
+  }
+
   const defaultFrom = hoursAgo(limits.defaultTimeRangeHours)
   const defaultTo = now()
 
@@ -1669,6 +1736,7 @@ export async function incidentsEventsV2(
   }
 
   // Convert to array and calculate durations
+  const tz = params.timezone
   const incidentList: IncidentEvent[] = [...incidents.values()].map((inc) => {
     let duration: string | undefined
     if (inc.recoveredAt) {
@@ -1682,7 +1750,7 @@ export async function incidentsEventsV2(
       }
     }
 
-    return {
+    const base: IncidentEvent = {
       monitorName: inc.monitorName,
       firstTrigger: inc.firstTrigger.toISOString(),
       lastTrigger: inc.lastTrigger.toISOString(),
@@ -1690,8 +1758,20 @@ export async function incidentsEventsV2(
       recovered: inc.recovered,
       recoveredAt: inc.recoveredAt?.toISOString(),
       duration,
-      sample: inc.sample
+      // Requirement 4: annotate the nested sample event timestamp when tz is supplied.
+      sample: tz !== undefined ? annotateEventTimezone(inc.sample, tz) : inc.sample
     }
+
+    // Requirement 4: opt-in sibling *Local strings for trigger/recovery timestamps.
+    if (tz !== undefined) {
+      base.firstTriggerLocal = formatLocal(inc.firstTrigger.getTime(), tz)
+      base.lastTriggerLocal = formatLocal(inc.lastTrigger.getTime(), tz)
+      if (inc.recoveredAt) {
+        base.recoveredAtLocal = formatLocal(inc.recoveredAt.getTime(), tz)
+      }
+    }
+
+    return base
   })
 
   // Sort by first trigger descending, apply limit
@@ -1894,7 +1974,8 @@ histogram: Bucket events by local hour_of_day / day_of_week / day_of_month in th
                 priority,
                 limit,
                 cursor,
-                transitionType
+                transitionType,
+                timezone
               },
               limits,
               site
@@ -1921,7 +2002,8 @@ histogram: Bucket events by local hour_of_day / day_of_week / day_of_month in th
                   tags,
                   groupBy,
                   limit,
-                  transitionType
+                  transitionType,
+                  timezone
                 },
                 limits,
                 site
@@ -1942,7 +2024,8 @@ histogram: Bucket events by local hour_of_day / day_of_week / day_of_month in th
                   groupBy,
                   contextTags,
                   maxEvents,
-                  transitionType
+                  transitionType,
+                  timezone
                 },
                 limits,
                 site
@@ -1997,7 +2080,8 @@ histogram: Bucket events by local hour_of_day / day_of_week / day_of_month in th
                   tags,
                   dedupeWindow,
                   limit,
-                  transitionType
+                  transitionType,
+                  timezone
                 },
                 limits,
                 site

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -5,6 +5,12 @@ import { handleDatadogError, requireParam, checkReadOnly } from '../errors/datad
 import { toolResult } from '../utils/format.js'
 import { hoursAgo, now, parseTime, ensureValidTimeRange, parseDurationToNs } from '../utils/time.js'
 import { buildEventsUrl } from '../utils/urls.js'
+import {
+  bucketHourOfDay,
+  bucketDayOfWeek,
+  bucketDayOfMonth,
+  validateIanaZone
+} from '../utils/timezone.js'
 import type { LimitsConfig } from '../config/schema.js'
 
 const ActionSchema = z.enum([
@@ -16,8 +22,12 @@ const ActionSchema = z.enum([
   'top',
   'timeseries',
   'incidents',
-  'discover'
+  'discover',
+  'histogram'
 ])
+
+const HistogramBucketBySchema = z.enum(['hour_of_day', 'day_of_week', 'day_of_month'])
+export type HistogramBucketBy = z.infer<typeof HistogramBucketBySchema>
 
 const InputSchema = {
   action: ActionSchema.describe('Action to perform'),
@@ -91,6 +101,16 @@ const InputSchema = {
     .optional()
     .describe(
       'Filter events by monitor state transition type. When set, restricts results to events with @monitor.transition.transition_type matching any value. Use ["alert","alert recovery"] to count real fires/recoveries and skip renotifies. Empty array is treated as undefined (no filter). For a fires-only count by monitor ID, prefer monitors action=history.'
+    ),
+  // Histogram action (Requirement 3): bucket events by local hour/day-of-week/day-of-month.
+  bucket_by: HistogramBucketBySchema.optional().describe(
+    'Bucket dimension for histogram action: hour_of_day (0-23), day_of_week (0=Sun..6=Sat), day_of_month (1-31).'
+  ),
+  timezone: z
+    .string()
+    .optional()
+    .describe(
+      'IANA timezone for histogram bucketing (e.g. "UTC", "Europe/Paris"). DST-safe. Default: UTC.'
     )
 }
 
@@ -846,6 +866,214 @@ export async function searchEventsV2(
   return baseResult
 }
 
+// ============ Histogram action (Requirement 3) ============
+
+/**
+ * Output shape for the `events.histogram` action.
+ *
+ * `buckets` is an object map keyed by stringified bucket key (e.g. `"0".."23"`
+ * for hour_of_day, `"0".."6"` for day_of_week, `"1".."31"` for day_of_month).
+ * Object form chosen so JSON output is self-describing and stable across
+ * runtimes — see design.md Requirement 3 / task DoD.
+ */
+export interface EventsHistogramOutput {
+  buckets: Record<string, number>
+  bucketBy: HistogramBucketBy
+  timezone: string
+  totalEvents: number
+  bucketCountIncomplete?: boolean
+  nextCursor?: string
+  meta: {
+    query: string
+    from: string
+    to: string
+    datadog_url: string
+  }
+}
+
+/**
+ * Bucket a single event timestamp (epoch milliseconds) into the requested
+ * dimension, in the requested IANA timezone.
+ *
+ * All zone math is delegated to `src/utils/timezone.ts`, which uses
+ * `Intl.DateTimeFormat` — DST-safe by construction.
+ */
+function bucketEvent(epochMs: number, bucketBy: HistogramBucketBy, tz: string): number {
+  switch (bucketBy) {
+    case 'hour_of_day':
+      return bucketHourOfDay(epochMs, tz)
+    case 'day_of_week':
+      return bucketDayOfWeek(epochMs, tz)
+    case 'day_of_month':
+      return bucketDayOfMonth(epochMs, tz)
+    default: {
+      // Exhaustiveness — z.enum prevents this at the input boundary, but the
+      // assertion guards against future variants slipping through.
+      const exhaustive: never = bucketBy
+      throw new Error(`Unhandled bucket_by: ${String(exhaustive)}`)
+    }
+  }
+}
+
+/**
+ * Convert a Datadog v2 event timestamp into epoch milliseconds.
+ *
+ * The v2 events SDK sometimes returns `attributes.timestamp` as an ISO 8601
+ * string and sometimes as a `Date` (depending on serializer config). We accept
+ * either — and silently skip any event whose timestamp cannot be parsed,
+ * rather than crashing the entire histogram on a single bad row.
+ */
+function eventEpochMs(event: v2.EventResponse): number | null {
+  const ts = event.attributes?.timestamp
+  if (ts === undefined || ts === null) return null
+  if (ts instanceof Date) {
+    const ms = ts.getTime()
+    return Number.isFinite(ms) ? ms : null
+  }
+  // Strings and numbers both parse via Date(); guard against NaN.
+  const ms = new Date(String(ts)).getTime()
+  return Number.isFinite(ms) ? ms : null
+}
+
+/**
+ * Client-side histogram for events.
+ *
+ * Paginates `searchEvents` with the supplied cursor (or starts fresh), bucketing
+ * each event in the requested IANA timezone. Stops as soon as either:
+ *  - the underlying API runs out of pages, or
+ *  - we hit `limits.maxEventsForHistogram` (returning `bucketCountIncomplete: true`
+ *    and the `nextCursor` so a follow-up call can resume).
+ *
+ * The timezone is validated up-front: an invalid zone throws `EINVALID_TIMEZONE`
+ * BEFORE any Datadog request is made.
+ */
+export async function histogramEventsV2(
+  api: v2.EventsApi,
+  params: {
+    query?: string
+    from?: string
+    to?: string
+    sources?: string[]
+    tags?: string[]
+    bucket_by: HistogramBucketBy
+    timezone?: string
+    cursor?: string
+  },
+  limits: LimitsConfig,
+  site: string
+): Promise<EventsHistogramOutput> {
+  const timezone = params.timezone ?? 'UTC'
+
+  // Validate the zone BEFORE any Datadog call so an invalid zone never burns
+  // an API request quota.
+  validateIanaZone(timezone)
+
+  const defaultFrom = hoursAgo(limits.defaultTimeRangeHours)
+  const defaultTo = now()
+
+  const [validFrom, validTo] = ensureValidTimeRange(
+    parseTime(params.from, defaultFrom),
+    parseTime(params.to, defaultTo)
+  )
+  const fromTime = new Date(validFrom * 1000).toISOString()
+  const toTime = new Date(validTo * 1000).toISOString()
+
+  const fullQuery = buildEventQuery({
+    query: params.query,
+    sources: params.sources,
+    tags: params.tags
+  })
+
+  const cap = limits.maxEventsForHistogram
+  // Per-page limit caps at 1000 (Datadog API max). When the histogram cap is
+  // smaller (e.g. tight limits in tests) honor that to avoid overshooting.
+  const perPage = Math.max(1, Math.min(1000, cap))
+
+  const buckets: Record<string, number> = {}
+  let totalEvents = 0
+  let cursor: string | undefined = params.cursor
+  let bucketCountIncomplete = false
+  let exhaustedPages = false
+
+  // Bound pagination to avoid runaway loops even in pathological fixtures.
+  const maxPages = 100
+  let pageCount = 0
+
+  while (pageCount < maxPages) {
+    const body: v2.EventsListRequest = {
+      filter: {
+        query: fullQuery,
+        from: fromTime,
+        to: toTime
+      },
+      sort: 'timestamp' as v2.EventsSort,
+      page: {
+        limit: perPage,
+        cursor
+      }
+    }
+
+    const response = await api.searchEvents({ body })
+    const data = response.data ?? []
+    const responseCursor = response.meta?.page?.after ?? undefined
+
+    for (const event of data) {
+      const epochMs = eventEpochMs(event)
+      if (epochMs === null) continue
+      const bucket = bucketEvent(epochMs, params.bucket_by, timezone)
+      const key = String(bucket)
+      buckets[key] = (buckets[key] ?? 0) + 1
+      totalEvents++
+
+      if (totalEvents >= cap) {
+        // Cap reached mid-page. Use the cursor from THIS response as the
+        // continuation token; it points at the page boundary, not a per-event
+        // offset (Datadog cursor semantics).
+        bucketCountIncomplete = true
+        cursor = responseCursor
+        break
+      }
+    }
+
+    if (bucketCountIncomplete) break
+
+    if (data.length === 0 || !responseCursor) {
+      exhaustedPages = true
+      break
+    }
+
+    cursor = responseCursor
+    pageCount++
+  }
+
+  const result: EventsHistogramOutput = {
+    buckets,
+    bucketBy: params.bucket_by,
+    timezone,
+    totalEvents,
+    meta: {
+      query: fullQuery,
+      from: fromTime,
+      to: toTime,
+      datadog_url: buildEventsUrl(fullQuery, validFrom, validTo, site)
+    }
+  }
+
+  if (bucketCountIncomplete) {
+    result.bucketCountIncomplete = true
+    if (cursor) {
+      result.nextCursor = cursor
+    }
+  } else if (!exhaustedPages && pageCount >= maxPages && cursor) {
+    // Defensive: page guard hit (shouldn't happen in normal flows). Surface
+    // a continuation token rather than silently truncating.
+    result.bucketCountIncomplete = true
+    result.nextCursor = cursor
+  }
+
+  return result
+}
+
 /**
  * Client-side aggregation for events
  * Streams through all matching events and counts by group key
@@ -1570,7 +1798,7 @@ export function registerEventsTool(
 ): void {
   server.tool(
     'events',
-    `Track Datadog events. Actions: list, get, create, search, aggregate, top, timeseries, incidents, discover.
+    `Track Datadog events. Actions: list, get, create, search, aggregate, top, timeseries, incidents, discover, histogram.
 For monitor alerts, use tags: ["source:alert"].
 
 IMPORTANT — re-evaluation vs transition:
@@ -1588,7 +1816,8 @@ discover: Returns available tag prefixes from events.
 aggregate: Custom groupBy, returns pipe-delimited keys.
 search: Full event details.
 timeseries: Time-bucketed trends with interval.
-incidents: Deduplicate alerts with dedupeWindow.`,
+incidents: Deduplicate alerts with dedupeWindow.
+histogram: Bucket events by local hour_of_day / day_of_week / day_of_month in the requested IANA timezone (DST-safe). Pass bucket_by (required) and optional timezone (default UTC) and cursor (for continuation). Caps at limits.maxEventsForHistogram (default 5000); when reached returns bucketCountIncomplete:true + nextCursor.`,
     InputSchema,
     async ({
       action,
@@ -1610,7 +1839,9 @@ incidents: Deduplicate alerts with dedupeWindow.`,
       enrich,
       contextTags,
       maxEvents,
-      transitionType
+      transitionType,
+      bucket_by,
+      timezone
     }) => {
       try {
         checkReadOnly(action, readOnly)
@@ -1772,6 +2003,27 @@ incidents: Deduplicate alerts with dedupeWindow.`,
                 site
               )
             )
+
+          case 'histogram': {
+            const histogramBucketBy = requireParam(bucket_by, 'bucket_by', 'histogram')
+            return toolResult(
+              await histogramEventsV2(
+                apiV2,
+                {
+                  query,
+                  from,
+                  to,
+                  sources,
+                  tags,
+                  bucket_by: histogramBucketBy,
+                  timezone,
+                  cursor
+                },
+                limits,
+                site
+              )
+            )
+          }
 
           default:
             throw new Error(`Unknown action: ${action}`)

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -706,6 +706,7 @@ export function computeDiagnostics(input: {
   const diagnostics: EventsDiagnostic[] = []
 
   const query = input.query ?? ''
+  // NOSONAR S5852: anchored alternation, no nested quantifiers, input is bounded user query string
   const queryHasSourceAlert =
     /(^|\s|\()source:alert(\s|\)|$)/.test(query) ||
     (input.sources?.includes('alert') ?? false) ||

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -531,6 +531,182 @@ export async function createEventV1(
   }
 }
 
+// ============ Zero-result diagnostics for events.search ============
+
+/**
+ * Diagnostic codes attached to zero-result `events.search` responses.
+ * Mirrored in `src/schema/events.ts` so agents can introspect them.
+ */
+export type EventsDiagnosticCode =
+  | 'UNINDEXED_TAG_PREFIX'
+  | 'NARROW_TIME_RANGE'
+  | 'RESTRICTIVE_SOURCE_FILTER'
+
+export interface EventsDiagnostic {
+  code: EventsDiagnosticCode
+  message: string
+  hint?: string
+}
+
+/**
+ * Seed list of tag prefixes commonly used to filter `source:alert` events that
+ * Datadog does NOT index server-side. Filtering on these will silently return
+ * zero results even when a matching event exists.
+ *
+ * Sources:
+ * - Datadog event search syntax docs:
+ *   https://docs.datadoghq.com/service_management/events/explorer/searching/
+ * - Datadog monitor notification variables (these surface as event attributes
+ *   but are not indexed as tags):
+ *   https://docs.datadoghq.com/monitors/notify/variables/
+ * - Project issue #49 — reported empty result sets when filtering alert events
+ *   by `monitor_priority`, `notification_preset`, and similar monitor-sourced
+ *   attributes.
+ *
+ * Keep this list narrow and conservative; false positives degrade the hint
+ * quality. Update when Datadog publishes new indexing guidance.
+ */
+export const UNINDEXED_ALERT_TAG_PREFIXES: ReadonlyArray<string> = [
+  'monitor_priority',
+  'notification_preset',
+  'monitor_tags',
+  'alert_cycle_key',
+  'monitor_group_key',
+  'notification_method'
+]
+
+/**
+ * Threshold below which a queried time range is flagged as narrow.
+ * 5 minutes — matches the typical minimum alert evaluation window.
+ */
+const NARROW_TIME_RANGE_THRESHOLD_MS = 5 * 60 * 1000
+
+/**
+ * Internal: extract tag prefixes referenced in a Datadog query string and in
+ * a `tags` array. Tag prefixes are the substring before the first colon, e.g.
+ * `monitor_priority:P1` → `monitor_priority`.
+ */
+function extractTagPrefixes(query: string | undefined, tags: string[] | undefined): string[] {
+  const prefixes: string[] = []
+
+  if (query) {
+    // Match bare `<word>:<value>` filters in the query. We deliberately avoid
+    // a complex parser — the heuristic stays at single-token granularity.
+    const re = /(?:^|\s)([a-zA-Z_][a-zA-Z0-9_]*):[^\s)]+/g
+    let match: RegExpExecArray | null
+    while ((match = re.exec(query)) !== null) {
+      if (match[1]) {
+        prefixes.push(match[1])
+      }
+    }
+  }
+
+  if (tags) {
+    for (const tag of tags) {
+      const colonIdx = tag.indexOf(':')
+      if (colonIdx > 0) {
+        prefixes.push(tag.slice(0, colonIdx))
+      }
+    }
+  }
+
+  return prefixes
+}
+
+/**
+ * Internal: count the distinct query terms in a Datadog event query string,
+ * excluding `source:*` filters. Used to detect a "source-only" query.
+ */
+function countNonSourceTerms(query: string | undefined): number {
+  if (!query) return 0
+  const tokens = query.split(/\s+/).filter((t) => t.length > 0 && t !== 'OR' && t !== 'AND')
+  let nonSource = 0
+  for (const token of tokens) {
+    // Strip parentheses introduced by buildEventQuery for grouped source filters.
+    const stripped = token.replace(/[()]/g, '')
+    if (stripped.length === 0) continue
+    if (stripped.startsWith('source:')) continue
+    nonSource++
+  }
+  return nonSource
+}
+
+/**
+ * Compute diagnostic hints for a zero-result `events.search` call.
+ *
+ * The heuristic is intentionally local and conservative:
+ * - O(query length) string scans only — no Datadog API calls.
+ * - Designed to run in under 5ms on typical query input.
+ * - Returns an empty array when the query offers no actionable hint.
+ *
+ * Only invoked when the underlying search returned zero events.
+ */
+export function computeDiagnostics(input: {
+  query?: string
+  tags?: string[]
+  sources?: string[]
+  fromMs?: number
+  toMs?: number
+}): EventsDiagnostic[] {
+  const diagnostics: EventsDiagnostic[] = []
+
+  const query = input.query ?? ''
+  const queryHasSourceAlert =
+    /(^|\s|\()source:alert(\s|\)|$)/.test(query) ||
+    (input.sources?.includes('alert') ?? false) ||
+    (input.tags?.includes('source:alert') ?? false)
+
+  // ----- UNINDEXED_TAG_PREFIX -----
+  // Only emit on alert-source queries — that's where the known-unindexed
+  // attributes apply. Other event sources have different indexing rules and
+  // a false positive would be noisier than helpful.
+  if (queryHasSourceAlert) {
+    const prefixes = extractTagPrefixes(input.query, input.tags)
+    const unindexedHits = prefixes.filter((p) => UNINDEXED_ALERT_TAG_PREFIXES.includes(p))
+    const uniqueHits = Array.from(new Set(unindexedHits))
+    if (uniqueHits.length > 0) {
+      diagnostics.push({
+        code: 'UNINDEXED_TAG_PREFIX',
+        message: `Query filters on tag prefix(es) that Datadog does not index for source:alert events: ${uniqueHits.join(', ')}.`,
+        hint: 'Drop these filters and post-filter the results client-side, or aggregate via monitors/get + monitors.list with matching options.'
+      })
+    }
+  }
+
+  // ----- NARROW_TIME_RANGE -----
+  if (
+    typeof input.fromMs === 'number' &&
+    typeof input.toMs === 'number' &&
+    input.toMs > input.fromMs &&
+    input.toMs - input.fromMs < NARROW_TIME_RANGE_THRESHOLD_MS
+  ) {
+    diagnostics.push({
+      code: 'NARROW_TIME_RANGE',
+      message: 'Time range is shorter than 5 minutes; alert events may not have been indexed yet.',
+      hint: 'Widen the range (e.g. last 1h) or retry after the indexing delay (~30s) has elapsed.'
+    })
+  }
+
+  // ----- RESTRICTIVE_SOURCE_FILTER -----
+  // Emit when the caller filtered on source:alert with no other meaningful
+  // query terms (the typical anti-pattern of "give me all alerts in the last
+  // 24h" returning nothing because no alerts fired).
+  if (queryHasSourceAlert) {
+    const otherTerms = countNonSourceTerms(input.query)
+    const otherTags = (input.tags ?? []).filter((t) => !t.startsWith('source:')).length
+    if (otherTerms === 0 && otherTags === 0) {
+      diagnostics.push({
+        code: 'RESTRICTIVE_SOURCE_FILTER',
+        message:
+          'Only source:alert filter was applied; the matching event set may genuinely be empty.',
+        hint: 'Use events.aggregate or monitors.list to confirm no alerts fired in the window, or broaden sources (e.g. source:monitor, source:audit).'
+      })
+    }
+  }
+
+  return diagnostics
+}
+
 // ============ V2 API Functions (new capabilities) ============
 
 /**
@@ -642,7 +818,7 @@ export async function searchEventsV2(
   const events = (response.data ?? []).map(formatEventV2)
   const nextCursor = response.meta?.page?.after
 
-  return {
+  const baseResult = {
     events,
     meta: {
       count: events.length,
@@ -653,6 +829,21 @@ export async function searchEventsV2(
       datadog_url: buildEventsUrl(fullQuery, validFrom, validTo, site)
     }
   }
+
+  // Requirement 5: attach diagnostics only on zero-result responses.
+  // Skip entirely on the happy path to avoid shape inflation and latency.
+  if (events.length === 0) {
+    const diagnostics = computeDiagnostics({
+      query: params.query,
+      tags: params.tags,
+      sources: params.sources,
+      fromMs: validFrom * 1000,
+      toMs: validTo * 1000
+    })
+    return { ...baseResult, diagnostics }
+  }
+
+  return baseResult
 }
 
 /**

--- a/src/tools/metrics.ts
+++ b/src/tools/metrics.ts
@@ -95,7 +95,7 @@ export function parseRollupFromQuery(query: string): ParsedRollup | null {
   // We use a non-greedy capture and an explicit closing-paren anchor so nested
   // parens inside the rollup args don't trip the match (the supported subset is
   // simple: method + interval). The `g` flag with `matchAll` gives us all candidates.
-  const matches = [...query.matchAll(/\.rollup\(\s*([^)]*?)\s*\)/g)]
+  const matches = [...query.matchAll(/\.rollup\(\s*([^)]*?)\s*\)/g)] // NOSONAR S5852: bounded query input, polynomial backtracking
   const lastMatch = matches[matches.length - 1]
   if (lastMatch === undefined) return null
 

--- a/src/tools/metrics.ts
+++ b/src/tools/metrics.ts
@@ -47,6 +47,125 @@ interface MetricSeriesData {
   tags: string[]
 }
 
+/**
+ * Whitelisted Datadog rollup methods (mirrors src/schema/metrics.ts rollupMethods).
+ */
+const ROLLUP_METHODS = new Set(['avg', 'max', 'min', 'sum', 'count'])
+
+/**
+ * Default rollup method per Datadog docs when only an interval is passed
+ * (e.g. `rollup(60)`). We surface this via `methodInferred: true` so callers
+ * can tell the difference between an echo of their request and our default.
+ * Source: https://docs.datadoghq.com/dashboards/functions/rollup/
+ */
+const DEFAULT_ROLLUP_METHOD = 'avg'
+
+/**
+ * Requested rollup parsed out of the query string.
+ *
+ * `methodInferred` resolves design.md OQ-3: when the query only specifies an
+ * interval (e.g. `rollup(60)`), Datadog defaults to `avg`. We echo that default
+ * and flag it so the caller doesn't mistake it for an explicit request.
+ */
+export interface ParsedRollup {
+  interval: number
+  method: string
+  methodInferred: boolean
+}
+
+/**
+ * Extract a `rollup(method, seconds)` clause from a Datadog metrics query string.
+ *
+ * Tolerant by design — returns `null` rather than throwing on:
+ *   - missing rollup clause
+ *   - unrecognized rollup method
+ *   - non-integer interval
+ *   - empty argument list
+ *
+ * Supported forms:
+ *   - `rollup(method, seconds)` → both fields parsed, `methodInferred: false`
+ *   - `rollup(seconds)`         → method defaults to `avg`, `methodInferred: true`
+ *
+ * Whitespace inside the parentheses is tolerated.
+ */
+export function parseRollupFromQuery(query: string): ParsedRollup | null {
+  if (typeof query !== 'string') return null
+  // Match the LAST rollup(...) call in the query so chained expressions like
+  // `default_zero(...).rollup(sum, 900).as_count()` resolve to the outermost rollup.
+  // We use a non-greedy capture and an explicit closing-paren anchor so nested
+  // parens inside the rollup args don't trip the match (the supported subset is
+  // simple: method + interval). The `g` flag with `matchAll` gives us all candidates.
+  const matches = [...query.matchAll(/\.rollup\(\s*([^)]*?)\s*\)/g)]
+  const lastMatch = matches[matches.length - 1]
+  if (lastMatch === undefined) return null
+
+  const inner = lastMatch[1]
+  if (inner === undefined || inner.length === 0) return null
+
+  const parts = inner.split(',').map((p) => p.trim())
+
+  if (parts.length === 1) {
+    // rollup(seconds) — only the interval is provided; method defaults to avg.
+    const raw = parts[0] ?? ''
+    const interval = Number.parseInt(raw, 10)
+    if (!Number.isFinite(interval) || interval <= 0 || String(interval) !== raw) {
+      return null
+    }
+    return { interval, method: DEFAULT_ROLLUP_METHOD, methodInferred: true }
+  }
+
+  if (parts.length === 2) {
+    const method = parts[0] ?? ''
+    const secondsRaw = parts[1] ?? ''
+    if (!ROLLUP_METHODS.has(method)) return null
+    const interval = Number.parseInt(secondsRaw, 10)
+    if (!Number.isFinite(interval) || interval <= 0 || String(interval) !== secondsRaw) {
+      return null
+    }
+    return { interval, method, methodInferred: false }
+  }
+
+  return null
+}
+
+/**
+ * Compute the rollup-effective metadata from a Datadog series payload.
+ *
+ * Datadog's response doesn't expose the rollup interval directly — we derive it
+ * from the spacing between the first two points in each series (in ms, converted
+ * to seconds). Single-point series contribute nothing (we can't measure spacing).
+ *
+ * Returns:
+ *   - `null` when no observable interval can be derived (empty series or all
+ *     series have <2 points). In that case `rollupOverridden` cannot be asserted
+ *     and must default to `false`.
+ *   - `{ interval, intervalsObserved? }` otherwise. `intervalsObserved` is the
+ *     deduped, ascending list when more than one distinct interval was observed.
+ */
+function computeEffectiveRollup(
+  series: ReadonlyArray<{ pointlist?: ReadonlyArray<[number, number]> }>
+): { interval: number; intervalsObserved?: number[] } | null {
+  const intervals: number[] = []
+  for (const s of series) {
+    const pts = s.pointlist ?? []
+    if (pts.length < 2) continue
+    const first = pts[0]
+    const second = pts[1]
+    if (first === undefined || second === undefined) continue
+    const deltaMs = (second[0] ?? 0) - (first[0] ?? 0)
+    if (deltaMs <= 0) continue
+    intervals.push(Math.round(deltaMs / 1000))
+  }
+  const primary = intervals[0]
+  if (primary === undefined) return null
+
+  const unique = Array.from(new Set(intervals)).sort((a, b) => a - b)
+  if (unique.length === 1) {
+    return { interval: primary }
+  }
+  return { interval: primary, intervalsObserved: unique }
+}
+
 export async function queryMetrics(
   api: v1.MetricsApi,
   params: {
@@ -73,7 +192,8 @@ export async function queryMetrics(
     query: params.query
   })
 
-  const series: MetricSeriesData[] = (response.series ?? []).map((s) => ({
+  const rawSeries = response.series ?? []
+  const series: MetricSeriesData[] = rawSeries.map((s) => ({
     metric: s.metric ?? '',
     points: (s.pointlist ?? [])
       .slice(0, params.pointLimit ?? limits.defaultMetricDataPoints)
@@ -85,6 +205,21 @@ export async function queryMetrics(
     tags: s.tagSet ?? []
   }))
 
+  // Rollup-override metadata (design.md Requirement 2).
+  // Effective interval is computed from raw `pointlist` so it stays accurate
+  // even when the caller passed a small `pointLimit`.
+  const rollupRequested = parseRollupFromQuery(params.query)
+  const rollupEffective = computeEffectiveRollup(
+    rawSeries.map((s) => ({
+      pointlist: (s.pointlist ?? []) as ReadonlyArray<[number, number]>
+    }))
+  )
+  const rollupOverridden =
+    rollupRequested !== null &&
+    rollupEffective !== null &&
+    (rollupEffective.interval !== rollupRequested.interval ||
+      (rollupEffective.intervalsObserved?.some((i) => i !== rollupRequested.interval) ?? false))
+
   return {
     series,
     meta: {
@@ -92,7 +227,10 @@ export async function queryMetrics(
       from: new Date(fromTs * 1000).toISOString(),
       to: new Date(toTs * 1000).toISOString(),
       seriesCount: series.length,
-      datadog_url: buildMetricsUrl(params.query, fromTs, toTs, site)
+      datadog_url: buildMetricsUrl(params.query, fromTs, toTs, site),
+      rollupRequested,
+      rollupEffective,
+      rollupOverridden
     }
   }
 }

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -1,4 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js'
 import { z } from 'zod'
 import { v1, v2 } from '@datadog/datadog-api-client'
 import { handleDatadogError, requireParam, checkReadOnly } from '../errors/datadog.js'
@@ -27,7 +28,8 @@ const ActionSchema = z.enum([
   'unmute',
   'top',
   'history',
-  'preview'
+  'preview',
+  'test_notification'
 ])
 
 // Mustache-subset preview context — keep loose at the schema boundary so we
@@ -1013,6 +1015,52 @@ export async function previewMonitor(
   return monitorId !== undefined ? { ...result, monitorId } : result
 }
 
+/**
+ * Trigger a Datadog monitor test notification (Requirement 6 / OQ-1).
+ *
+ * **Status: ENOT_SUPPORTED — Datadog has no public test-notification endpoint.**
+ *
+ * Research conducted during Task 8 of the events-dx-improvements spec
+ * (.kiro/specs/events-dx-improvements/tasks.md) audited the Datadog public
+ * OpenAPI specifications at:
+ *   - https://github.com/DataDog/datadog-api-client-python/blob/master/.generator/schemas/v1/openapi.yaml
+ *   - https://github.com/DataDog/datadog-api-client-python/blob/master/.generator/schemas/v2/openapi.yaml
+ *
+ * The full set of `/api/v1/monitor*` paths is:
+ *   `POST/GET /api/v1/monitor`, `GET /api/v1/monitor/can_delete`,
+ *   `GET /api/v1/monitor/groups/search`, `GET /api/v1/monitor/search`,
+ *   `POST /api/v1/monitor/validate`,
+ *   `GET/PUT/DELETE /api/v1/monitor/{monitor_id}`,
+ *   `GET /api/v1/monitor/{monitor_id}/downtimes`,
+ *   `POST /api/v1/monitor/{monitor_id}/validate`.
+ *
+ * The v2 monitor surface (`/api/v2/monitor/notification_rule`,
+ * `/api/v2/monitor/policy`, `/api/v2/monitor/template`, `monitor template
+ * validate`, `monitor downtime_matches`) likewise exposes no `/notify` or
+ * `/test` path. Confirmed against the SDK type definitions at
+ * `node_modules/@datadog/datadog-api-client/dist/packages/datadog-api-client-v1/apis/MonitorsApi.d.ts`
+ * (no `notifyMonitor` / `testMonitor` methods).
+ *
+ * See also Datadog's official monitor API reference for current state:
+ *   https://docs.datadoghq.com/api/latest/monitors/
+ *
+ * Per design.md Requirement 6 AC2 and Open Question OQ-1, this action returns
+ * an explicit `ENOT_SUPPORTED` error including a documentation pointer instead
+ * of silently degrading or faking a success response. Read-only mode allows
+ * this action (Requirement 6 AC4) because no Datadog HTTP call is attempted.
+ *
+ * If Datadog later publishes a public test-notification endpoint, this handler
+ * should switch to invoking it via the SDK's raw request configuration and
+ * surface 429 verbatim via `handleDatadogError` (Requirement 6 AC5) with no
+ * auto-retry.
+ */
+export const TEST_NOTIFICATION_NOT_SUPPORTED_MESSAGE =
+  "ENOT_SUPPORTED: action 'test_notification' is not implemented — the Datadog public REST API exposes no monitor test-notification endpoint at v1 or v2 as of the events-dx-improvements spec. Use the Datadog UI's 'Test Notifications' button on the monitor page, or open an issue if Datadog publishes such an endpoint. Reference: https://docs.datadoghq.com/api/latest/monitors/"
+
+export function testNotificationMonitor(_args: { monitorId?: string }): never {
+  throw new McpError(ErrorCode.InvalidRequest, TEST_NOTIFICATION_NOT_SUPPORTED_MESSAGE)
+}
+
 export async function updateMonitor(
   api: v1.MonitorsApi,
   id: string,
@@ -1279,7 +1327,7 @@ export function registerMonitorsTool(
 ): void {
   server.tool(
     'monitors',
-    `Manage Datadog monitors. Actions: list, get, search, create, update, delete, mute, unmute, top, history, preview.
+    `Manage Datadog monitors. Actions: list, get, search, create, update, delete, mute, unmute, top, history, preview, test_notification.
 Filters: name, tags, groupStates (alert/warn/ok/no data).
 get/create/update return the full options object so callers can safely read-then-patch.
 
@@ -1324,6 +1372,13 @@ preview: Render a Datadog monitor message template against a context (read-only 
   - Missing variables render as {{undefined:name}} markers and are reported in 'variablesMissing'.
   - Loops ({{#each ...}}) and partials ({{> ...}}) return EUNSUPPORTED_TEMPLATE_SYNTAX.
   - Allowed under --read-only (no mutation; at most a getMonitor load).
+
+test_notification: KNOWN LIMITATION — always returns ENOT_SUPPORTED.
+  - Datadog's public REST API exposes no monitor test-notification endpoint at v1 or v2
+    (audited against the official OpenAPI specs). The v1 SDK has no notifyMonitor / testMonitor method.
+  - Allowed under --read-only because no Datadog HTTP call is attempted.
+  - If Datadog publishes such an endpoint in future, this action will be reimplemented to invoke it.
+  - Workaround: use the 'Test Notifications' button in the Datadog monitor UI.
 
 For generic event grouping (deployments, configs), use events tool instead. Note that the
 events tool's action=search with source:alert ALSO includes renotifies; use its
@@ -1458,6 +1513,19 @@ transitionType filter (or this action=history) for fires-only counts.`,
                 site
               )
             )
+          }
+
+          case 'test_notification': {
+            // Requirement 6 / OQ-1: the Datadog public API exposes no
+            // test-notification endpoint, so we surface ENOT_SUPPORTED and do
+            // not attempt a Datadog HTTP call. See JSDoc on
+            // `testNotificationMonitor` for the OpenAPI-spec audit.
+            // `testNotificationMonitor` returns `never` (it always throws),
+            // but we wrap the call in `return` to keep ESLint's no-fallthrough
+            // and TypeScript's switch-exhaustiveness rules both happy.
+            const monitorIdSource =
+              monitorIdNum !== undefined ? String(monitorIdNum) : (id ?? undefined)
+            return testNotificationMonitor({ monitorId: monitorIdSource })
           }
 
           default:

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -7,6 +7,12 @@ import { buildMonitorUrl, buildMonitorsListUrl } from '../utils/urls.js'
 import { hoursAgo, now, parseTime, ensureValidTimeRange } from '../utils/time.js'
 import { buildEventsUrl } from '../utils/urls.js'
 import { formatEventV2 } from './events.js'
+import {
+  renderMonitorTemplate,
+  SUPPORTED_CONDITIONALS,
+  type PreviewResult,
+  type TemplateContext
+} from '../utils/templatePreview.js'
 import type { LimitsConfig } from '../config/schema.js'
 
 const ActionSchema = z.enum([
@@ -19,8 +25,20 @@ const ActionSchema = z.enum([
   'mute',
   'unmute',
   'top',
-  'history'
+  'history',
+  'preview'
 ])
+
+// Mustache-subset preview context — keep loose at the schema boundary so we
+// surface our own EUNSUPPORTED_TEMPLATE_SYNTAX / variablesMissing semantics
+// from `renderMonitorTemplate` rather than zod-rejecting unknown variable keys.
+const PreviewContextSchema = z
+  .object({
+    variables: z.record(z.unknown()).optional(),
+    conditionals: z.record(z.boolean()).optional()
+  })
+  .optional()
+  .describe('Substitution context for monitors.preview (variables + conditionals).')
 
 const InputSchema = {
   action: ActionSchema.describe('Action to perform'),
@@ -40,8 +58,23 @@ const InputSchema = {
     .optional()
     .describe('Maximum number of monitors to return (default: 50)'),
   config: z.record(z.unknown()).optional().describe('Monitor configuration (for create/update)'),
-  message: z.string().optional().describe('Mute message (for mute action)'),
+  message: z
+    .string()
+    .optional()
+    .describe(
+      'Mute message (for mute action) OR inline template source for the preview action. ' +
+        'For preview, supply either this inline string or `monitor_id` (or the existing `id` ' +
+        'field) so the action can load the monitor message via getMonitor.'
+    ),
   end: z.number().optional().describe('Mute end timestamp (for mute action)'),
+  monitor_id: z
+    .number()
+    .optional()
+    .describe(
+      'Numeric monitor ID used by the preview action when no inline `message` is supplied. ' +
+        'Equivalent to passing the existing `id` field as a numeric string.'
+    ),
+  context: PreviewContextSchema,
   // Top action parameters
   from: z
     .string()
@@ -881,6 +914,50 @@ export async function dryRunMonitor(
   }
 }
 
+/**
+ * Render a Datadog monitor message template against a caller-supplied context.
+ *
+ * Source of the template:
+ *   - If `inlineMessage` is provided, it is used verbatim.
+ *   - Otherwise `monitorIdSource` is loaded via `getMonitor(api, ..., site)` and
+ *     its `.message` field is used as the template.
+ *
+ * Read-only safety: this action performs at most a read of an existing monitor
+ * (no mutation). The dispatcher therefore allows it under `--read-only`.
+ *
+ * Supported subset matches `renderMonitorTemplate` — see
+ * `src/utils/templatePreview.ts` for the full grammar and error contracts.
+ * Unsupported Mustache constructs (loops, partials, unknown conditionals)
+ * surface as `EUNSUPPORTED_TEMPLATE_SYNTAX`.
+ */
+export async function previewMonitor(
+  api: v1.MonitorsApi,
+  args: {
+    inlineMessage?: string
+    monitorIdSource?: string
+    context?: TemplateContext
+  },
+  site: string = 'datadoghq.com'
+): Promise<PreviewResult & { monitorId?: number }> {
+  let template: string
+  let monitorId: number | undefined
+
+  if (args.inlineMessage !== undefined && args.inlineMessage !== '') {
+    template = args.inlineMessage
+  } else if (args.monitorIdSource !== undefined && args.monitorIdSource !== '') {
+    const loaded = await getMonitor(api, args.monitorIdSource, site)
+    template = loaded.monitor.message ?? ''
+    monitorId = loaded.monitor.id
+  } else {
+    throw new Error(
+      "Action 'preview' requires either an inline 'message' or a 'monitor_id' (or 'id') to load the template from."
+    )
+  }
+
+  const result = renderMonitorTemplate(template, args.context ?? {})
+  return monitorId !== undefined ? { ...result, monitorId } : result
+}
+
 export async function updateMonitor(
   api: v1.MonitorsApi,
   id: string,
@@ -1147,7 +1224,7 @@ export function registerMonitorsTool(
 ): void {
   server.tool(
     'monitors',
-    `Manage Datadog monitors. Actions: list, get, search, create, update, delete, mute, unmute, top, history.
+    `Manage Datadog monitors. Actions: list, get, search, create, update, delete, mute, unmute, top, history, preview.
 Filters: name, tags, groupStates (alert/warn/ok/no data).
 get/create/update return the full options object so callers can safely read-then-patch.
 
@@ -1185,6 +1262,14 @@ history: Count and list real state transitions for one monitor over a time windo
     transition_type filter that excludes renotifies by default. To include renotifies, pass
     transitionType including "renotify".
 
+preview: Render a Datadog monitor message template against a context (read-only safe).
+  - Inputs: either inline 'message' OR 'monitor_id' (or existing 'id'); plus optional 'context' { variables, conditionals }.
+  - Supported syntax: {{variable.name}} substitution and conditional blocks {{#name}}...{{/name}} / {{^name}}...{{/name}}
+    where name is one of: ${SUPPORTED_CONDITIONALS.join(', ')}.
+  - Missing variables render as {{undefined:name}} markers and are reported in 'variablesMissing'.
+  - Loops ({{#each ...}}) and partials ({{> ...}}) return EUNSUPPORTED_TEMPLATE_SYNTAX.
+  - Allowed under --read-only (no mutation; at most a getMonitor load).
+
 For generic event grouping (deployments, configs), use events tool instead. Note that the
 events tool's action=search with source:alert ALSO includes renotifies; use its
 transitionType filter (or this action=history) for fires-only counts.`,
@@ -1198,6 +1283,7 @@ transitionType filter (or this action=history) for fires-only counts.`,
       groupStates,
       limit,
       config,
+      message,
       end,
       from,
       to,
@@ -1205,7 +1291,9 @@ transitionType filter (or this action=history) for fires-only counts.`,
       maxEvents,
       transitionType,
       group,
-      dry_run: dryRun
+      dry_run: dryRun,
+      monitor_id: monitorIdNum,
+      context
     }) => {
       try {
         // Dry-run create is a non-mutating validation call against POST
@@ -1292,6 +1380,25 @@ transitionType filter (or this action=history) for fires-only counts.`,
                 monitorId,
                 { from, to, transitionType, group },
                 limits,
+                site
+              )
+            )
+          }
+
+          case 'preview': {
+            // Caller may pass either the new numeric `monitor_id` or the
+            // existing stringly-typed `id`. Both resolve to the same getMonitor
+            // call inside `previewMonitor`. Inline `message` wins when supplied.
+            const monitorIdSource =
+              monitorIdNum !== undefined ? String(monitorIdNum) : (id ?? undefined)
+            return toolResult(
+              await previewMonitor(
+                api,
+                {
+                  inlineMessage: message,
+                  monitorIdSource,
+                  context: context as TemplateContext | undefined
+                },
                 site
               )
             )

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -13,6 +13,7 @@ import {
   type PreviewResult,
   type TemplateContext
 } from '../utils/templatePreview.js'
+import { validateIanaZone, formatLocal } from '../utils/timezone.js'
 import type { LimitsConfig } from '../config/schema.js'
 
 const ActionSchema = z.enum([
@@ -123,6 +124,14 @@ const InputSchema = {
       'When create + dry_run=true, validate the monitor body via POST /api/v1/monitor/validate ' +
         'without creating it. Allowed under --read-only because no monitor is created. ' +
         'Returns { valid, dryRun, monitor }. 400 responses surface verbatim like a failed create.'
+    ),
+  timezone: z
+    .string()
+    .optional()
+    .describe(
+      'Optional IANA timezone (e.g. "UTC", "Europe/Paris"). When supplied on get/list, ' +
+        'the response adds sibling createdLocal/modifiedLocal ISO 8601 strings next to created/modified. ' +
+        'Omit for byte-identical legacy shape. Invalid zones return EINVALID_TIMEZONE.'
     )
 }
 
@@ -315,6 +324,32 @@ interface MonitorSummary {
   created: string
   modified: string
   url: string
+  /**
+   * Requirement 4: ISO 8601 with offset in the requested IANA timezone.
+   * Present ONLY when the caller supplied a `timezone` parameter. Omitting
+   * `timezone` produces a response shape byte-identical to today.
+   */
+  createdLocal?: string
+  modifiedLocal?: string
+}
+
+/**
+ * Requirement 4: annotate a MonitorSummary (or MonitorDetail) with sibling
+ * `createdLocal` / `modifiedLocal` ISO 8601 strings in the requested IANA
+ * timezone. Returns a shallow copy; the original is untouched. Empty or
+ * unparseable timestamps are left annotated as undefined rather than crashing.
+ */
+function annotateMonitorTimezone<T extends MonitorSummary>(monitor: T, tz: string): T {
+  const annotated: T = { ...monitor }
+  if (monitor.created) {
+    const ms = new Date(monitor.created).getTime()
+    if (Number.isFinite(ms)) annotated.createdLocal = formatLocal(ms, tz)
+  }
+  if (monitor.modified) {
+    const ms = new Date(monitor.modified).getTime()
+    if (Number.isFinite(ms)) annotated.modifiedLocal = formatLocal(ms, tz)
+  }
+  return annotated
 }
 
 export function formatMonitor(m: v1.Monitor, site: string = 'datadoghq.com'): MonitorSummary {
@@ -709,8 +744,15 @@ export async function listMonitors(
   api: v1.MonitorsApi,
   params: { name?: string; tags?: string[]; groupStates?: string[]; limit?: number },
   limits: LimitsConfig,
-  site: string
+  site: string,
+  timezone?: string
 ) {
+  // Requirement 4: validate timezone BEFORE the Datadog call so an invalid zone
+  // never burns API quota and surfaces a stable EINVALID_TIMEZONE.
+  if (timezone !== undefined) {
+    validateIanaZone(timezone)
+  }
+
   const effectiveLimit = params.limit ?? limits.defaultLimit
 
   const response = await api.listMonitors({
@@ -719,7 +761,12 @@ export async function listMonitors(
     groupStates: params.groupStates?.join(',')
   })
 
-  const monitors = response.slice(0, effectiveLimit).map((m) => formatMonitor(m, site))
+  const baseMonitors = response.slice(0, effectiveLimit).map((m) => formatMonitor(m, site))
+  // Requirement 4: opt-in *Local annotations only when timezone is supplied.
+  const monitors =
+    timezone !== undefined
+      ? baseMonitors.map((m) => annotateMonitorTimezone(m, timezone))
+      : baseMonitors
 
   const statusCounts = {
     total: response.length,
@@ -739,15 +786,23 @@ export async function listMonitors(
   }
 }
 
-export async function getMonitor(api: v1.MonitorsApi, id: string, site: string) {
+export async function getMonitor(api: v1.MonitorsApi, id: string, site: string, timezone?: string) {
+  // Requirement 4: validate timezone BEFORE the Datadog call.
+  if (timezone !== undefined) {
+    validateIanaZone(timezone)
+  }
+
   const monitorId = Number.parseInt(id, 10)
   if (Number.isNaN(monitorId)) {
     throw new Error(`Invalid monitor ID: ${id}`)
   }
 
   const monitor = await api.getMonitor({ monitorId })
+  const baseDetail = formatMonitorDetail(monitor, site)
+  // Requirement 4: opt-in *Local annotations only when timezone is supplied.
+  const detail = timezone !== undefined ? annotateMonitorTimezone(baseDetail, timezone) : baseDetail
   return {
-    monitor: formatMonitorDetail(monitor, site),
+    monitor: detail,
     datadog_url: buildMonitorUrl(monitorId, site)
   }
 }
@@ -1293,7 +1348,8 @@ transitionType filter (or this action=history) for fires-only counts.`,
       group,
       dry_run: dryRun,
       monitor_id: monitorIdNum,
-      context
+      context,
+      timezone
     }) => {
       try {
         // Dry-run create is a non-mutating validation call against POST
@@ -1308,12 +1364,12 @@ transitionType filter (or this action=history) for fires-only counts.`,
         switch (action) {
           case 'list':
             return toolResult(
-              await listMonitors(api, { name, tags, groupStates, limit }, limits, site)
+              await listMonitors(api, { name, tags, groupStates, limit }, limits, site, timezone)
             )
 
           case 'get': {
             const monitorId = requireParam(id, 'id', 'get')
-            return toolResult(await getMonitor(api, monitorId, site))
+            return toolResult(await getMonitor(api, monitorId, site, timezone))
           }
 
           case 'search': {

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -82,6 +82,14 @@ const InputSchema = {
     .optional()
     .describe(
       'For history action: filter transitions to a specific multi-alert monitor group (e.g., "pod_name:foo,kube_namespace:bar"). Optional; omit for all groups.'
+    ),
+  dry_run: z
+    .boolean()
+    .optional()
+    .describe(
+      'When create + dry_run=true, validate the monitor body via POST /api/v1/monitor/validate ' +
+        'without creating it. Allowed under --read-only because no monitor is created. ' +
+        'Returns { valid, dryRun, monitor }. 400 responses surface verbatim like a failed create.'
     )
 }
 
@@ -850,6 +858,29 @@ export async function createMonitor(
   return result
 }
 
+/**
+ * Validate a monitor body without creating it (dry-run).
+ * Calls POST /api/v1/monitor/validate. The Datadog SDK exposes this as
+ * `v1.MonitorsApi.validateMonitor({ body })`. A 400 response surfaces verbatim
+ * via `handleDatadogError`, matching the error shape a failed create would yield.
+ *
+ * Read-only safety: this endpoint is non-mutating, so the dispatcher allows
+ * `action: 'create'` with `dry_run: true` even when `--read-only` is set.
+ */
+export async function dryRunMonitor(
+  api: v1.MonitorsApi,
+  config: Record<string, unknown>
+): Promise<{ valid: true; dryRun: true; monitor: Record<string, unknown> }> {
+  const normalized = normalizeMonitorConfig(config)
+  const body = normalized as unknown as v1.Monitor
+  await api.validateMonitor({ body })
+  return {
+    valid: true,
+    dryRun: true,
+    monitor: normalized
+  }
+}
+
 export async function updateMonitor(
   api: v1.MonitorsApi,
   id: string,
@@ -1173,10 +1204,19 @@ transitionType filter (or this action=history) for fires-only counts.`,
       contextTags,
       maxEvents,
       transitionType,
-      group
+      group,
+      dry_run: dryRun
     }) => {
       try {
-        checkReadOnly(action, readOnly)
+        // Dry-run create is a non-mutating validation call against POST
+        // /api/v1/monitor/validate. Skip the write-action read-only gate when
+        // (action === 'create' && dryRun === true); for any other branch the
+        // standard gate applies, so plain `create` (or omitted dry_run) is
+        // still blocked under --read-only.
+        const isDryRunCreate = action === 'create' && dryRun === true
+        if (!isDryRunCreate) {
+          checkReadOnly(action, readOnly)
+        }
         switch (action) {
           case 'list':
             return toolResult(
@@ -1195,6 +1235,9 @@ transitionType filter (or this action=history) for fires-only counts.`,
 
           case 'create': {
             const monitorConfig = requireParam(config, 'config', 'create')
+            if (dryRun) {
+              return toolResult(await dryRunMonitor(api, monitorConfig))
+            }
             return toolResult(await createMonitor(api, monitorConfig, site))
           }
 

--- a/src/tools/monitors.ts
+++ b/src/tools/monitors.ts
@@ -38,7 +38,9 @@ const ActionSchema = z.enum([
 const PreviewContextSchema = z
   .object({
     variables: z.record(z.unknown()).optional(),
-    conditionals: z.record(z.boolean()).optional()
+    conditionals: z
+      .record(z.enum(SUPPORTED_CONDITIONALS as unknown as [string, ...string[]]), z.boolean())
+      .optional()
   })
   .optional()
   .describe('Substitution context for monitors.preview (variables + conditionals).')

--- a/src/tools/schema.ts
+++ b/src/tools/schema.ts
@@ -7,7 +7,7 @@ const ResourceSchema = z.enum(schemaResources as [SchemaResource, ...SchemaResou
 
 const InputSchema = {
   resource: ResourceSchema.describe(
-    'Datadog resource type to get schema for: dashboards, metrics, monitors, slos'
+    'Datadog resource type to get schema for: dashboards, events, metrics, monitors, slos'
   )
 }
 

--- a/src/utils/templatePreview.ts
+++ b/src/utils/templatePreview.ts
@@ -113,8 +113,7 @@ type Token =
   | { kind: 'literal'; text: string }
   | { kind: 'block'; conditional: MonitorConditional; negated: boolean; children: Token[] }
 
-// NOSONAR S5852: input is monitor message templates (bounded, trusted); adjacent \s*/[^}]*?/\s* yields polynomial not exponential backtracking, bounded by template length
-const TAG_REGEX = /\{\{\s*([#^/>])?\s*([^}]*?)\s*\}\}/g
+const TAG_REGEX = /\{\{\s*([#^/>])?\s*([^}]*?)\s*\}\}/g // NOSONAR S5852: bounded template input, polynomial backtracking
 
 /**
  * Parse the raw template into a tree of literal text and conditional blocks.
@@ -247,8 +246,7 @@ function renderBlocks(
   return out
 }
 
-// NOSONAR S5852: input is monitor message templates (bounded, trusted); adjacent \s*/[^}]*?/\s* yields polynomial not exponential backtracking, bounded by template length
-const VARIABLE_TAG_REGEX = /\{\{\s*([^#^/>\s][^}]*?)\s*\}\}/g
+const VARIABLE_TAG_REGEX = /\{\{\s*([^#^/>\s][^}]*?)\s*\}\}/g // NOSONAR S5852: bounded template input, polynomial backtracking
 
 /**
  * Substitute `{{variable.name}}` tags in the already conditional-resolved text.

--- a/src/utils/templatePreview.ts
+++ b/src/utils/templatePreview.ts
@@ -113,6 +113,7 @@ type Token =
   | { kind: 'literal'; text: string }
   | { kind: 'block'; conditional: MonitorConditional; negated: boolean; children: Token[] }
 
+// NOSONAR S5852: input is monitor message templates (bounded, trusted); adjacent \s*/[^}]*?/\s* yields polynomial not exponential backtracking, bounded by template length
 const TAG_REGEX = /\{\{\s*([#^/>])?\s*([^}]*?)\s*\}\}/g
 
 /**
@@ -246,6 +247,7 @@ function renderBlocks(
   return out
 }
 
+// NOSONAR S5852: input is monitor message templates (bounded, trusted); adjacent \s*/[^}]*?/\s* yields polynomial not exponential backtracking, bounded by template length
 const VARIABLE_TAG_REGEX = /\{\{\s*([^#^/>\s][^}]*?)\s*\}\}/g
 
 /**

--- a/src/utils/templatePreview.ts
+++ b/src/utils/templatePreview.ts
@@ -1,0 +1,300 @@
+/**
+ * Monitor message template preview — Datadog's documented Mustache subset.
+ *
+ * Supported syntax:
+ *   - {{variable.name}}                         — variable substitution (dot-path lookup)
+ *   - {{#is_alert}}...{{/is_alert}}            — positive conditional
+ *   - {{^is_warning}}...{{/is_warning}}        — negated conditional
+ *
+ * Supported conditionals (fixed set, see design.md §Data model — MonitorConditional):
+ *   is_alert, is_warning, is_no_data, is_recovery,
+ *   is_alert_to_warning, is_warning_to_alert
+ *
+ * Unsupported (throws EUNSUPPORTED_TEMPLATE_SYNTAX):
+ *   - {{#each ...}}     loops
+ *   - {{> name}}        partials
+ *   - any conditional name outside the supported set
+ *
+ * Processing order:
+ *   1. Resolve conditional blocks (depth-first; nested blocks fully resolved before parent).
+ *   2. Substitute remaining variables in the resulting literal text.
+ *
+ * Variables that are not present in `context.variables` render as
+ * `{{undefined:name}}` and are reported in `variablesMissing`.
+ * Missing conditionals default to `false`.
+ */
+
+/** Fixed set of conditionals supported by Datadog monitor messages. */
+export const SUPPORTED_CONDITIONALS = [
+  'is_alert',
+  'is_warning',
+  'is_no_data',
+  'is_recovery',
+  'is_alert_to_warning',
+  'is_warning_to_alert'
+] as const
+
+export type MonitorConditional = (typeof SUPPORTED_CONDITIONALS)[number]
+
+export interface TemplateContext {
+  variables?: Record<string, unknown>
+  conditionals?: Partial<Record<MonitorConditional, boolean>>
+}
+
+export interface PreviewResult {
+  rendered: string
+  variablesUsed: string[]
+  variablesMissing: string[]
+  conditionalsResolved: Record<string, boolean>
+}
+
+const SUPPORTED_SET: ReadonlySet<string> = new Set(SUPPORTED_CONDITIONALS)
+
+/**
+ * Build the standard EUNSUPPORTED_TEMPLATE_SYNTAX error message.
+ * The message enumerates the supported subset so the caller can self-correct.
+ */
+function unsupportedSyntaxError(detail: string): Error {
+  const supportedList = SUPPORTED_CONDITIONALS.join(', ')
+  return new Error(
+    `EUNSUPPORTED_TEMPLATE_SYNTAX: ${detail}. ` +
+      `Supported syntax is {{variable.name}} and conditionals ` +
+      `{{#name}}...{{/name}} / {{^name}}...{{/name}} where name is one of: ${supportedList}. ` +
+      `Loops ({{#each ...}}) and partials ({{> ...}}) are not supported.`
+  )
+}
+
+/**
+ * Look up a dot-notation path against the variables map.
+ *
+ * Lookup strategy:
+ *   1. Direct match — if `variables[fullPath]` exists, use it.
+ *   2. Deep walk — split on `.` and walk a nested object literal.
+ *
+ * Returns `undefined` when the path is not resolvable, so the caller can
+ * emit a `{{undefined:name}}` marker.
+ */
+function lookupVariable(path: string, variables: Record<string, unknown>): string | undefined {
+  // Strategy 1: flat key with dots
+  if (Object.prototype.hasOwnProperty.call(variables, path)) {
+    const value = variables[path]
+    return value === undefined || value === null ? undefined : String(value)
+  }
+
+  // Strategy 2: deep walk
+  const segments = path.split('.')
+  let cursor: unknown = variables
+  for (const segment of segments) {
+    if (cursor === null || cursor === undefined) {
+      return undefined
+    }
+    if (typeof cursor !== 'object') {
+      return undefined
+    }
+    const record = cursor as Record<string, unknown>
+    if (!Object.prototype.hasOwnProperty.call(record, segment)) {
+      return undefined
+    }
+    cursor = record[segment]
+  }
+
+  if (cursor === undefined || cursor === null) {
+    return undefined
+  }
+  if (typeof cursor === 'object') {
+    // Refuse to stringify a non-leaf — treat as missing.
+    return undefined
+  }
+  return String(cursor)
+}
+
+/** Token types produced by the conditional-block parser. */
+type Token =
+  | { kind: 'literal'; text: string }
+  | { kind: 'block'; conditional: MonitorConditional; negated: boolean; children: Token[] }
+
+const TAG_REGEX = /\{\{\s*([#^/>])?\s*([^}]*?)\s*\}\}/g
+
+/**
+ * Parse the raw template into a tree of literal text and conditional blocks.
+ * Detects unsupported constructs (loops, partials, unknown conditionals) and
+ * throws EUNSUPPORTED_TEMPLATE_SYNTAX immediately — never silently degrades.
+ *
+ * Variables are NOT consumed here; they remain inside the `literal` text and
+ * are substituted in a later pass.
+ */
+function parseBlocks(template: string): Token[] {
+  type Frame = {
+    children: Token[]
+    closer?: { conditional: MonitorConditional; negated: boolean }
+  }
+
+  const stack: Frame[] = [{ children: [] }]
+  let cursor = 0
+  TAG_REGEX.lastIndex = 0
+
+  let match: RegExpExecArray | null
+  while ((match = TAG_REGEX.exec(template)) !== null) {
+    const [fullTag, prefix, rawName] = match
+    const tagStart = match.index
+    const name = rawName?.trim() ?? ''
+
+    // Capture any literal text between the previous cursor and this tag.
+    if (tagStart > cursor) {
+      const top = stack[stack.length - 1]
+      if (top) {
+        top.children.push({ kind: 'literal', text: template.slice(cursor, tagStart) })
+      }
+    }
+
+    if (prefix === '>') {
+      throw unsupportedSyntaxError(`partials are not supported (found {{> ${name}}})`)
+    }
+
+    if (prefix === '#' || prefix === '^') {
+      // Reject loops outright.
+      if (name.startsWith('each') || /\s/.test(name)) {
+        throw unsupportedSyntaxError(`loops are not supported (found {{${prefix}${name}}})`)
+      }
+      if (!SUPPORTED_SET.has(name)) {
+        throw unsupportedSyntaxError(`unknown conditional '${name}' in {{${prefix}${name}}}`)
+      }
+      stack.push({
+        children: [],
+        closer: { conditional: name as MonitorConditional, negated: prefix === '^' }
+      })
+    } else if (prefix === '/') {
+      const frame = stack.pop()
+      if (!frame || !frame.closer) {
+        throw unsupportedSyntaxError(`unmatched closing tag {{/${name}}}`)
+      }
+      if (frame.closer.conditional !== name) {
+        throw unsupportedSyntaxError(
+          `mismatched closing tag {{/${name}}} (expected {{/${frame.closer.conditional}}})`
+        )
+      }
+      const parent = stack[stack.length - 1]
+      if (!parent) {
+        throw unsupportedSyntaxError('block stack underflow while closing tag')
+      }
+      parent.children.push({
+        kind: 'block',
+        conditional: frame.closer.conditional,
+        negated: frame.closer.negated,
+        children: frame.children
+      })
+    } else {
+      // Plain variable tag — preserve verbatim for the variable-substitution pass.
+      const top = stack[stack.length - 1]
+      if (top) {
+        top.children.push({ kind: 'literal', text: fullTag })
+      }
+    }
+
+    cursor = tagStart + fullTag.length
+  }
+
+  // Trailing literal after the last tag.
+  if (cursor < template.length) {
+    const top = stack[stack.length - 1]
+    if (top) {
+      top.children.push({ kind: 'literal', text: template.slice(cursor) })
+    }
+  }
+
+  if (stack.length !== 1) {
+    const open = stack[stack.length - 1]?.closer?.conditional
+    throw unsupportedSyntaxError(`unclosed conditional block ${open ? `{{#${open}}}` : ''}`)
+  }
+
+  const root = stack[0]
+  if (!root) {
+    throw unsupportedSyntaxError('parser produced no root frame')
+  }
+  return root.children
+}
+
+/**
+ * Walk the parsed token tree, evaluate conditionals, and emit the literal
+ * (still containing variable tags) text for the variable-substitution pass.
+ *
+ * Records every conditional we encounter — even ones in dropped branches —
+ * so callers see the full resolution map.
+ */
+function renderBlocks(
+  tokens: readonly Token[],
+  conditionals: Partial<Record<MonitorConditional, boolean>>,
+  resolved: Record<string, boolean>
+): string {
+  let out = ''
+  for (const token of tokens) {
+    if (token.kind === 'literal') {
+      out += token.text
+      continue
+    }
+    const flag = conditionals[token.conditional] ?? false
+    resolved[token.conditional] = flag
+    const include = token.negated ? !flag : flag
+    if (include) {
+      out += renderBlocks(token.children, conditionals, resolved)
+    } else {
+      // Even in a dropped branch, descend so nested conditionals are recorded
+      // in `conditionalsResolved`. Discard the rendered output.
+      renderBlocks(token.children, conditionals, resolved)
+    }
+  }
+  return out
+}
+
+const VARIABLE_TAG_REGEX = /\{\{\s*([^#^/>\s][^}]*?)\s*\}\}/g
+
+/**
+ * Substitute `{{variable.name}}` tags in the already conditional-resolved text.
+ * Missing variables produce `{{undefined:name}}` markers and are reported.
+ */
+function substituteVariables(
+  text: string,
+  variables: Record<string, unknown>
+): { rendered: string; used: string[]; missing: string[] } {
+  const usedSet = new Set<string>()
+  const missingSet = new Set<string>()
+
+  const rendered = text.replace(VARIABLE_TAG_REGEX, (_match, captured: string) => {
+    const name = captured.trim()
+    const value = lookupVariable(name, variables)
+    if (value === undefined) {
+      missingSet.add(name)
+      return `{{undefined:${name}}}`
+    }
+    usedSet.add(name)
+    return value
+  })
+
+  return {
+    rendered,
+    used: [...usedSet],
+    missing: [...missingSet]
+  }
+}
+
+/**
+ * Render a Datadog monitor message template against the provided context.
+ *
+ * See module-level JSDoc for the supported subset and processing order.
+ */
+export function renderMonitorTemplate(template: string, context: TemplateContext): PreviewResult {
+  const variables = context.variables ?? {}
+  const conditionals = context.conditionals ?? {}
+
+  const tree = parseBlocks(template)
+  const conditionalsResolved: Record<string, boolean> = {}
+  const afterConditionals = renderBlocks(tree, conditionals, conditionalsResolved)
+  const { rendered, used, missing } = substituteVariables(afterConditionals, variables)
+
+  return {
+    rendered,
+    variablesUsed: used,
+    variablesMissing: missing,
+    conditionalsResolved
+  }
+}

--- a/src/utils/timezone.ts
+++ b/src/utils/timezone.ts
@@ -1,0 +1,296 @@
+/**
+ * Timezone utilities for IANA-zone-aware formatting and bucketing.
+ *
+ * Implements Requirements 3 and 4 (events-dx-improvements):
+ *  - `validateIanaZone` — throws `EINVALID_TIMEZONE` with up to 3 near-match suggestions
+ *  - `formatLocal` — ISO 8601 string with offset (DST-safe)
+ *  - `bucketHourOfDay` / `bucketDayOfWeek` / `bucketDayOfMonth` — local bucketing
+ *
+ * All zone math goes through `Intl.DateTimeFormat`. No manual offset arithmetic
+ * anywhere — DST transitions are handled by the runtime ICU database.
+ */
+
+const ERROR_PREFIX = 'EINVALID_TIMEZONE'
+
+/**
+ * Day-of-week numeric mapping used by `bucketDayOfWeek`.
+ * Matches `Date.prototype.getDay` semantics: 0=Sunday..6=Saturday.
+ * Design.md §65-70 fixes this convention.
+ */
+const WEEKDAY_TO_INDEX: Record<string, number> = {
+  Sunday: 0,
+  Monday: 1,
+  Tuesday: 2,
+  Wednesday: 3,
+  Thursday: 4,
+  Friday: 5,
+  Saturday: 6
+}
+
+/**
+ * Throws if `tz` is not a valid IANA timezone identifier.
+ *
+ * The check delegates to `new Intl.DateTimeFormat(undefined, { timeZone: tz })`,
+ * which throws a `RangeError` for unknown zones. On rejection we surface a
+ * stable `EINVALID_TIMEZONE` error with up to 3 near-match suggestions taken
+ * from `Intl.supportedValuesOf('timeZone')`.
+ *
+ * Accepts canonical zones like `UTC`, `Europe/Paris`, `America/New_York`.
+ */
+export function validateIanaZone(tz: string): void {
+  if (typeof tz !== 'string' || tz.length === 0) {
+    throw new Error(
+      `${ERROR_PREFIX}: timezone must be a non-empty IANA identifier (e.g. "UTC", "Europe/Paris", "America/New_York")`
+    )
+  }
+
+  try {
+    // Intl.DateTimeFormat throws RangeError on invalid zone — single source of truth.
+    new Intl.DateTimeFormat('en-US', { timeZone: tz })
+    return
+  } catch {
+    const suggestions = suggestZones(tz)
+    const suggestionText = suggestions.length > 0 ? ` Did you mean: ${suggestions.join(', ')}?` : ''
+    throw new Error(`${ERROR_PREFIX}: "${tz}" is not a valid IANA timezone.${suggestionText}`)
+  }
+}
+
+/**
+ * Return up to 3 IANA timezone identifiers most similar to `input`.
+ *
+ * Strategy:
+ *  1. Case-insensitive substring matches (handles typos like "europe/pari" → "Europe/Paris").
+ *  2. Levenshtein distance fallback for zones not caught by substring.
+ *  3. Sort by ascending edit distance, take top 3.
+ */
+function suggestZones(input: string): string[] {
+  let zones: readonly string[]
+  try {
+    zones = Intl.supportedValuesOf('timeZone')
+  } catch {
+    // Older runtimes without supportedValuesOf — surface no suggestions rather than crash.
+    return []
+  }
+
+  const lower = input.toLowerCase()
+  const scored = zones.map((zone) => ({
+    zone,
+    score: scoreZone(zone, lower)
+  }))
+
+  scored.sort((a, b) => a.score - b.score)
+  return scored.slice(0, 3).map((s) => s.zone)
+}
+
+/**
+ * Lower score = better match. Substring matches get a strong boost.
+ */
+function scoreZone(zone: string, lowerInput: string): number {
+  const lowerZone = zone.toLowerCase()
+  const baseDistance = levenshtein(lowerZone, lowerInput)
+  if (lowerZone.includes(lowerInput) || lowerInput.includes(lowerZone)) {
+    // Subtract a constant so substring matches always beat pure edit-distance matches.
+    return baseDistance - 100
+  }
+  return baseDistance
+}
+
+/**
+ * Iterative Levenshtein with O(min(a,b)) memory.
+ */
+function levenshtein(a: string, b: string): number {
+  if (a.length === 0) return b.length
+  if (b.length === 0) return a.length
+
+  // Ensure `a` is the shorter string to bound row length.
+  if (a.length > b.length) {
+    const tmp = a
+    a = b
+    b = tmp
+  }
+
+  let previous = new Array<number>(a.length + 1)
+  let current = new Array<number>(a.length + 1)
+  for (let i = 0; i <= a.length; i++) previous[i] = i
+
+  for (let j = 1; j <= b.length; j++) {
+    current[0] = j
+    const bChar = b.charCodeAt(j - 1)
+    for (let i = 1; i <= a.length; i++) {
+      const cost = a.charCodeAt(i - 1) === bChar ? 0 : 1
+      const prevI = previous[i] ?? 0
+      const currIMinus1 = current[i - 1] ?? 0
+      const prevIMinus1 = previous[i - 1] ?? 0
+      current[i] = Math.min(prevI + 1, currIMinus1 + 1, prevIMinus1 + cost)
+    }
+    const tmp = previous
+    previous = current
+    current = tmp
+  }
+
+  return previous[a.length] ?? 0
+}
+
+/**
+ * Cached `Intl.DateTimeFormat` instances keyed by timezone.
+ * Avoids rebuilding formatters on every call to bucket* / formatLocal.
+ */
+const partsFormatterCache = new Map<string, Intl.DateTimeFormat>()
+const offsetFormatterCache = new Map<string, Intl.DateTimeFormat>()
+
+function getPartsFormatter(tz: string): Intl.DateTimeFormat {
+  const cached = partsFormatterCache.get(tz)
+  if (cached) return cached
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    hourCycle: 'h23', // 0-23, avoids "24" edge case at midnight
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    weekday: 'long'
+  })
+  partsFormatterCache.set(tz, fmt)
+  return fmt
+}
+
+function getOffsetFormatter(tz: string): Intl.DateTimeFormat {
+  const cached = offsetFormatterCache.get(tz)
+  if (cached) return cached
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    timeZoneName: 'longOffset'
+  })
+  offsetFormatterCache.set(tz, fmt)
+  return fmt
+}
+
+type DateParts = {
+  year: string
+  month: string
+  day: string
+  hour: string
+  minute: string
+  second: string
+  weekday: string
+}
+
+function getDateParts(epochMs: number, tz: string): DateParts {
+  let parts: Intl.DateTimeFormatPart[]
+  try {
+    parts = getPartsFormatter(tz).formatToParts(epochMs)
+  } catch {
+    // tz was rejected by Intl — surface the canonical error.
+    throw new Error(`${ERROR_PREFIX}: "${tz}" is not a valid IANA timezone.`)
+  }
+  const out: DateParts = {
+    year: '',
+    month: '',
+    day: '',
+    hour: '',
+    minute: '',
+    second: '',
+    weekday: ''
+  }
+  for (const part of parts) {
+    if (part.type === 'year') out.year = part.value
+    else if (part.type === 'month') out.month = part.value
+    else if (part.type === 'day') out.day = part.value
+    else if (part.type === 'hour') out.hour = part.value
+    else if (part.type === 'minute') out.minute = part.value
+    else if (part.type === 'second') out.second = part.value
+    else if (part.type === 'weekday') out.weekday = part.value
+  }
+  return out
+}
+
+/**
+ * Extract the offset for `epochMs` in `tz` as an ISO 8601 offset string
+ * (`+HH:MM`, `-HH:MM`, or `Z` for zero offset on the `UTC` zone).
+ *
+ * Uses `timeZoneName: 'longOffset'` which always emits `GMT±HH:MM`.
+ */
+function getOffsetIso(epochMs: number, tz: string): string {
+  let parts: Intl.DateTimeFormatPart[]
+  try {
+    parts = getOffsetFormatter(tz).formatToParts(epochMs)
+  } catch {
+    throw new Error(`${ERROR_PREFIX}: "${tz}" is not a valid IANA timezone.`)
+  }
+  const offsetPart = parts.find((p) => p.type === 'timeZoneName')
+  const raw = offsetPart?.value ?? ''
+  // raw is e.g. "GMT+02:00", "GMT-04:00", or "GMT" (zero offset, observed on some runtimes).
+  // Some runtimes emit "GMT+00:00" for UTC; some emit just "GMT".
+  if (raw === 'GMT' || raw === 'GMT+00:00' || raw === 'GMT-00:00') {
+    return 'Z'
+  }
+  if (raw.startsWith('GMT')) {
+    return raw.slice(3) // "+02:00"
+  }
+  // Fallback: surface as-is. This branch should not occur on supported Node versions.
+  return raw
+}
+
+/**
+ * Format `epochMs` as an ISO 8601 string with offset, in the given timezone.
+ *
+ * Examples:
+ *   formatLocal(Date.UTC(2026, 4, 14, 7, 15), 'Europe/Paris') → '2026-05-14T09:15:00+02:00'
+ *   formatLocal(Date.UTC(2026, 4, 14, 7, 15), 'UTC')          → '2026-05-14T07:15:00Z'
+ *
+ * Throws `EINVALID_TIMEZONE` on invalid `tz`.
+ */
+export function formatLocal(epochMs: number, tz: string): string {
+  validateIanaZone(tz)
+  const parts = getDateParts(epochMs, tz)
+  const offset = getOffsetIso(epochMs, tz)
+  return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}${offset}`
+}
+
+/**
+ * Return the hour-of-day bucket (0-23) for `epochMs` in `tz`.
+ *
+ * DST-safe via `Intl.DateTimeFormat` with `timeZone` option.
+ * On DST spring-forward in Europe/Paris (2026-03-29 02:00 → 03:00 local),
+ * an event at 01:30 UTC lands at 03:30 local → bucket 3.
+ * On DST fall-back (2026-10-25 03:00 → 02:00 local), an event at 01:30 UTC
+ * lands at 02:30 local → bucket 2.
+ *
+ * Throws `EINVALID_TIMEZONE` on invalid `tz`.
+ */
+export function bucketHourOfDay(epochMs: number, tz: string): number {
+  validateIanaZone(tz)
+  const parts = getDateParts(epochMs, tz)
+  return Number(parts.hour)
+}
+
+/**
+ * Return the day-of-week bucket for `epochMs` in `tz`.
+ * 0=Sunday..6=Saturday — matches `Date.prototype.getDay` semantics
+ * (see design.md §69), computed in the target zone.
+ *
+ * Throws `EINVALID_TIMEZONE` on invalid `tz`.
+ */
+export function bucketDayOfWeek(epochMs: number, tz: string): number {
+  validateIanaZone(tz)
+  const parts = getDateParts(epochMs, tz)
+  const index = WEEKDAY_TO_INDEX[parts.weekday]
+  if (index === undefined) {
+    // Defensive: should never happen on Node 18+ with `weekday: 'long'` in en-US.
+    throw new Error(`${ERROR_PREFIX}: could not resolve weekday for "${parts.weekday}" in "${tz}"`)
+  }
+  return index
+}
+
+/**
+ * Return the day-of-month bucket (1-31) for `epochMs` in `tz`.
+ *
+ * Throws `EINVALID_TIMEZONE` on invalid `tz`.
+ */
+export function bucketDayOfMonth(epochMs: number, tz: string): number {
+  validateIanaZone(tz)
+  const parts = getDateParts(epochMs, tz)
+  return Number(parts.day)
+}

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -66,6 +66,12 @@ export const monitors = {
       pageCount: 1,
       page: 0
     }
+  },
+  // Validate (dry-run) success — Datadog returns 200 with an empty body
+  validateOk: {},
+  // Validate (dry-run) 400 — Datadog returns the same error shape `create` would
+  validate400: {
+    errors: ['The value provided for parameter "query" is invalid']
   }
 }
 
@@ -185,6 +191,52 @@ export const metrics = {
     unit: 'percent',
     per_unit: null,
     statsd_interval: 10
+  },
+  // Datadog returned series at 3600s granularity when the caller asked for 900s.
+  // Used to assert meta.rollupOverridden=true on metrics.query responses.
+  queryRollupOverridden: {
+    series: [
+      {
+        metric: 'system.cpu.user',
+        display_name: 'CPU User',
+        pointlist: [
+          [1705750800000, 45.5],
+          [1705754400000, 48.2], // +3600000 ms (3600s) from previous
+          [1705758000000, 52.1]
+        ],
+        scope: 'host:prod-server-1',
+        unit: [{ name: 'percent' }]
+      }
+    ],
+    from_date: 1705750800000,
+    to_date: 1705758000000
+  },
+  // Two series returned at different intervals (e.g., split-screen aggregations).
+  queryRollupMixedIntervals: {
+    series: [
+      {
+        metric: 'system.cpu.user',
+        display_name: 'CPU User',
+        pointlist: [
+          [1705750800000, 45.5],
+          [1705754400000, 48.2] // 3600s interval
+        ],
+        scope: 'host:prod-server-1',
+        unit: [{ name: 'percent' }]
+      },
+      {
+        metric: 'system.cpu.user',
+        display_name: 'CPU User',
+        pointlist: [
+          [1705750800000, 41.0],
+          [1705751700000, 42.0] // 900s interval
+        ],
+        scope: 'host:prod-server-2',
+        unit: [{ name: 'percent' }]
+      }
+    ],
+    from_date: 1705750800000,
+    to_date: 1705758000000
   }
 }
 

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -72,6 +72,22 @@ export const monitors = {
   // Validate (dry-run) 400 — Datadog returns the same error shape `create` would
   validate400: {
     errors: ['The value provided for parameter "query" is invalid']
+  },
+  // Preview source — a monitor whose message exercises variable + conditional rendering.
+  // Used by the `preview` action when the caller supplies `monitor_id` instead of an
+  // inline `message`. See Requirement 7 in events-dx-improvements/design.md.
+  previewSource: {
+    id: 77777,
+    name: 'Preview Template Monitor',
+    type: 'metric alert',
+    query: 'avg(last_5m):avg:system.cpu.user{*} > 90',
+    message:
+      'CPU high on {{host.name}}.\n' +
+      '{{#is_alert}}ALERT branch{{/is_alert}}{{^is_alert}}OK branch{{/is_alert}}',
+    tags: ['env:production'],
+    overall_state: 'OK',
+    created: '2024-01-15T10:00:00.000Z',
+    modified: '2024-01-20T15:30:00.000Z'
   }
 }
 
@@ -467,6 +483,57 @@ export const events = {
           message: 'CPU usage exceeded threshold',
           timestamp: '2024-01-20T12:00:00.000Z',
           tags: ['source:alert', 'alert_type:error', 'host:prod-3', 'priority:normal']
+        }
+      }
+    ],
+    meta: {
+      page: {
+        after: null
+      }
+    }
+  },
+  // Events spread across hours-of-day for histogram tests.
+  // One event sits AT the Europe/Paris DST spring-forward boundary
+  // (2026-03-29T01:30:00Z → 03:30 local) so the test can prove the
+  // bucketing path is DST-safe.
+  eventsHistogramFixture: {
+    data: [
+      {
+        id: 'evt-hist-1',
+        attributes: {
+          title: 'event at 00:15 UTC',
+          message: '',
+          timestamp: '2026-03-29T00:15:00.000Z',
+          tags: ['source:alert']
+        }
+      },
+      {
+        id: 'evt-hist-2',
+        // DST spring-forward boundary in Europe/Paris.
+        // 01:30 UTC → 03:30 local (the 02:00-02:59 hour does not exist).
+        attributes: {
+          title: 'event at DST boundary 01:30 UTC',
+          message: '',
+          timestamp: '2026-03-29T01:30:00.000Z',
+          tags: ['source:alert']
+        }
+      },
+      {
+        id: 'evt-hist-3',
+        attributes: {
+          title: 'event at 05:00 UTC',
+          message: '',
+          timestamp: '2026-03-29T05:00:00.000Z',
+          tags: ['source:alert']
+        }
+      },
+      {
+        id: 'evt-hist-4',
+        attributes: {
+          title: 'event at 23:45 UTC',
+          message: '',
+          timestamp: '2026-03-29T23:45:00.000Z',
+          tags: ['source:alert']
         }
       }
     ],

--- a/tests/helpers/msw.ts
+++ b/tests/helpers/msw.ts
@@ -34,6 +34,7 @@ export const endpoints = {
   listMonitors: `${DD_API_V1}/monitor`,
   getMonitor: (id: number) => `${DD_API_V1}/monitor/${id}`,
   searchMonitors: `${DD_API_V1}/monitor/search`,
+  validateMonitor: `${DD_API_V1}/monitor/validate`,
 
   // Dashboards
   listDashboards: `${DD_API_V1}/dashboard`,

--- a/tests/tools/events.test.ts
+++ b/tests/tools/events.test.ts
@@ -13,6 +13,8 @@ import {
   createEventV1,
   searchEventsV2,
   histogramEventsV2,
+  aggregateEventsV2,
+  incidentsEventsV2,
   computeDiagnostics,
   UNINDEXED_ALERT_TAG_PREFIXES
 } from '../../src/tools/events.js'
@@ -789,6 +791,237 @@ describe('Events Tool', () => {
       )
 
       expect(observedCursor).toBe('resume-from-here')
+    })
+  })
+
+  // Requirement 4 (timezone annotation) — `timezone` is opt-in on read actions
+  // and adds sibling `*Local` ISO 8601 strings next to every existing epoch /
+  // ISO timestamp. Omitting `timezone` produces today's exact response shape.
+  describe('timezone annotation (Requirement 4)', () => {
+    describe('events.search', () => {
+      it('attaches timestampLocal to each event when timezone is provided', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(fixtures.searchV2)))
+
+        const result = await searchEventsV2(
+          apiV2,
+          {
+            query: 'source:alert',
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z',
+            timezone: 'Europe/Paris'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.events.length).toBeGreaterThan(0)
+        for (const event of result.events) {
+          expect(typeof event.timestampLocal).toBe('string')
+          // ISO 8601 with offset (or Z for UTC) — never the raw UTC trailing-Z form when zone != UTC.
+          expect(event.timestampLocal).toMatch(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([+-]\d{2}:\d{2}|Z)$/
+          )
+        }
+        // 2024-01-20T10:00:00Z in Europe/Paris (CET = UTC+1) → 11:00 local
+        const first = result.events[0]
+        expect(first?.timestamp).toBe('2024-01-20T10:00:00.000Z')
+        expect(first?.timestampLocal).toBe('2024-01-20T11:00:00+01:00')
+      })
+
+      it('does NOT add timestampLocal when timezone is omitted (byte-identical shape)', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(fixtures.searchV2)))
+
+        const result = await searchEventsV2(
+          apiV2,
+          {
+            query: 'source:alert',
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.events.length).toBeGreaterThan(0)
+        for (const event of result.events) {
+          expect(Object.prototype.hasOwnProperty.call(event, 'timestampLocal')).toBe(false)
+        }
+      })
+
+      it('throws EINVALID_TIMEZONE before any Datadog call when timezone is invalid', async () => {
+        let hit = false
+        server.use(
+          http.post(endpoints.searchEvents, () => {
+            hit = true
+            return jsonResponse(fixtures.searchV2)
+          })
+        )
+
+        await expect(
+          searchEventsV2(
+            apiV2,
+            {
+              query: 'source:alert',
+              timezone: 'Not/AValidZone'
+            },
+            defaultLimits,
+            defaultSite
+          )
+        ).rejects.toThrow(/EINVALID_TIMEZONE/)
+
+        expect(hit).toBe(false)
+      })
+    })
+
+    describe('events.aggregate', () => {
+      it('attaches timestampLocal to each bucket sample when timezone is provided', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(fixtures.searchV2)))
+
+        const result = await aggregateEventsV2(
+          apiV2,
+          {
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z',
+            timezone: 'Europe/Paris'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.buckets.length).toBeGreaterThan(0)
+        for (const bucket of result.buckets) {
+          expect(typeof bucket.sample.timestampLocal).toBe('string')
+          expect(bucket.sample.timestampLocal).toMatch(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([+-]\d{2}:\d{2}|Z)$/
+          )
+        }
+      })
+
+      it('does NOT add timestampLocal on samples when timezone omitted', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(fixtures.searchV2)))
+
+        const result = await aggregateEventsV2(
+          apiV2,
+          {
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        for (const bucket of result.buckets) {
+          expect(Object.prototype.hasOwnProperty.call(bucket.sample, 'timestampLocal')).toBe(false)
+        }
+      })
+
+      it('throws EINVALID_TIMEZONE before any Datadog call when timezone is invalid', async () => {
+        let hit = false
+        server.use(
+          http.post(endpoints.searchEvents, () => {
+            hit = true
+            return jsonResponse(fixtures.searchV2)
+          })
+        )
+
+        await expect(
+          aggregateEventsV2(
+            apiV2,
+            {
+              from: '2024-01-20T00:00:00Z',
+              to: '2024-01-20T23:59:59Z',
+              timezone: 'Not/AZone'
+            },
+            defaultLimits,
+            defaultSite
+          )
+        ).rejects.toThrow(/EINVALID_TIMEZONE/)
+        expect(hit).toBe(false)
+      })
+    })
+
+    describe('events.incidents', () => {
+      it('attaches *Local fields to firstTrigger / lastTrigger / recoveredAt when timezone is provided', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(fixtures.searchV2)))
+
+        const result = await incidentsEventsV2(
+          apiV2,
+          {
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z',
+            timezone: 'Europe/Paris'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.incidents.length).toBeGreaterThan(0)
+        for (const incident of result.incidents) {
+          expect(typeof incident.firstTriggerLocal).toBe('string')
+          expect(typeof incident.lastTriggerLocal).toBe('string')
+          expect(incident.firstTriggerLocal).toMatch(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([+-]\d{2}:\d{2}|Z)$/
+          )
+          // recoveredAtLocal only present when recoveredAt itself is present.
+          if (incident.recoveredAt) {
+            expect(typeof incident.recoveredAtLocal).toBe('string')
+          }
+          // The nested sample event must also get its own timestampLocal.
+          expect(typeof incident.sample.timestampLocal).toBe('string')
+        }
+      })
+
+      it('does NOT add *Local fields when timezone is omitted', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(fixtures.searchV2)))
+
+        const result = await incidentsEventsV2(
+          apiV2,
+          {
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        for (const incident of result.incidents) {
+          expect(Object.prototype.hasOwnProperty.call(incident, 'firstTriggerLocal')).toBe(false)
+          expect(Object.prototype.hasOwnProperty.call(incident, 'lastTriggerLocal')).toBe(false)
+          expect(Object.prototype.hasOwnProperty.call(incident, 'recoveredAtLocal')).toBe(false)
+          expect(Object.prototype.hasOwnProperty.call(incident.sample, 'timestampLocal')).toBe(
+            false
+          )
+        }
+      })
+    })
+
+    describe('events.histogram', () => {
+      it('throws EINVALID_TIMEZONE on invalid zone (already validated)', async () => {
+        // Sanity: histogram already validates via Task 5; this test ensures
+        // the behavior is preserved under Task 6 plumbing.
+        let hit = false
+        server.use(
+          http.post(endpoints.searchEvents, () => {
+            hit = true
+            return jsonResponse(fixtures.searchV2)
+          })
+        )
+
+        await expect(
+          histogramEventsV2(
+            apiV2,
+            {
+              bucket_by: 'hour_of_day',
+              timezone: 'Bogus/Zone',
+              from: '2024-01-20T00:00:00Z',
+              to: '2024-01-20T23:59:59Z'
+            },
+            defaultLimits,
+            defaultSite
+          )
+        ).rejects.toThrow(/EINVALID_TIMEZONE/)
+        expect(hit).toBe(false)
+      })
     })
   })
 })

--- a/tests/tools/events.test.ts
+++ b/tests/tools/events.test.ts
@@ -15,6 +15,7 @@ import {
   histogramEventsV2,
   aggregateEventsV2,
   incidentsEventsV2,
+  timeseriesEventsV2,
   computeDiagnostics,
   UNINDEXED_ALERT_TAG_PREFIXES
 } from '../../src/tools/events.js'
@@ -992,6 +993,80 @@ describe('Events Tool', () => {
             false
           )
         }
+      })
+    })
+
+    describe('events.timeseries', () => {
+      it('attaches timestampLocal to each bucket when timezone is provided', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(fixtures.searchV2)))
+
+        const result = await timeseriesEventsV2(
+          apiV2,
+          {
+            query: 'source:alert',
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z',
+            interval: '1h',
+            timezone: 'Europe/Paris'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.timeseries.length).toBeGreaterThan(0)
+        for (const bucket of result.timeseries) {
+          expect(typeof bucket.timestampLocal).toBe('string')
+          expect(bucket.timestampLocal).toMatch(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([+-]\d{2}:\d{2}|Z)$/
+          )
+        }
+      })
+
+      it('does NOT add timestampLocal when timezone is omitted (byte-identical shape)', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(fixtures.searchV2)))
+
+        const result = await timeseriesEventsV2(
+          apiV2,
+          {
+            query: 'source:alert',
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z',
+            interval: '1h'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.timeseries.length).toBeGreaterThan(0)
+        for (const bucket of result.timeseries) {
+          expect(Object.prototype.hasOwnProperty.call(bucket, 'timestampLocal')).toBe(false)
+        }
+      })
+
+      it('throws EINVALID_TIMEZONE before any Datadog call when timezone is invalid', async () => {
+        let hit = false
+        server.use(
+          http.post(endpoints.searchEvents, () => {
+            hit = true
+            return jsonResponse(fixtures.searchV2)
+          })
+        )
+
+        await expect(
+          timeseriesEventsV2(
+            apiV2,
+            {
+              query: 'source:alert',
+              from: '2024-01-20T00:00:00Z',
+              to: '2024-01-20T23:59:59Z',
+              interval: '1h',
+              timezone: 'Not/AZone'
+            },
+            defaultLimits,
+            defaultSite
+          )
+        ).rejects.toThrow(/EINVALID_TIMEZONE/)
+        expect(hit).toBe(false)
       })
     })
 

--- a/tests/tools/events.test.ts
+++ b/tests/tools/events.test.ts
@@ -7,7 +7,14 @@ import { http } from 'msw'
 import { server, endpoints, jsonResponse, errorResponse } from '../helpers/msw.js'
 import { createMockConfig } from '../helpers/mock.js'
 import { events as fixtures } from '../helpers/fixtures.js'
-import { listEventsV1, getEventV1, createEventV1, searchEventsV2 } from '../../src/tools/events.js'
+import {
+  listEventsV1,
+  getEventV1,
+  createEventV1,
+  searchEventsV2,
+  computeDiagnostics,
+  UNINDEXED_ALERT_TAG_PREFIXES
+} from '../../src/tools/events.js'
 import type { LimitsConfig } from '../../src/config/schema.js'
 
 const defaultLimits: LimitsConfig = {
@@ -211,6 +218,182 @@ describe('Events Tool', () => {
         searchEventsV2(apiV2, { query: '*' }, defaultLimits, defaultSite)
       ).rejects.toMatchObject({
         code: 401
+      })
+    })
+
+    describe('diagnostics on zero-result search', () => {
+      const emptyResponse = { data: [], meta: { page: { after: null } } }
+
+      it('should attach diagnostics field when result is empty', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(emptyResponse)))
+
+        const result = await searchEventsV2(
+          apiV2,
+          {
+            query: 'source:alert monitor_priority:P1',
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.events).toHaveLength(0)
+        expect(result.diagnostics).toBeDefined()
+        expect(Array.isArray(result.diagnostics)).toBe(true)
+      })
+
+      it('should NOT attach diagnostics field when result is non-empty', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(fixtures.searchV2)))
+
+        const result = await searchEventsV2(
+          apiV2,
+          {
+            query: 'source:alert',
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.events.length).toBeGreaterThan(0)
+        expect(Object.prototype.hasOwnProperty.call(result, 'diagnostics')).toBe(false)
+      })
+
+      it('should emit UNINDEXED_TAG_PREFIX when query targets an unindexed alert tag', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(emptyResponse)))
+
+        const result = await searchEventsV2(
+          apiV2,
+          {
+            query: 'source:alert monitor_priority:P1',
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        const codes = result.diagnostics?.map((d) => d.code) ?? []
+        expect(codes).toContain('UNINDEXED_TAG_PREFIX')
+      })
+
+      it('should emit UNINDEXED_TAG_PREFIX when tags param contains an unindexed prefix', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(emptyResponse)))
+
+        const result = await searchEventsV2(
+          apiV2,
+          {
+            query: 'source:alert',
+            tags: ['notification_preset:critical-pager'],
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        const codes = result.diagnostics?.map((d) => d.code) ?? []
+        expect(codes).toContain('UNINDEXED_TAG_PREFIX')
+      })
+
+      it('should emit NARROW_TIME_RANGE when range is under 5 minutes', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(emptyResponse)))
+
+        const result = await searchEventsV2(
+          apiV2,
+          {
+            query: 'host:prod-1',
+            from: '2024-01-20T10:00:00Z',
+            to: '2024-01-20T10:02:00Z'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        const codes = result.diagnostics?.map((d) => d.code) ?? []
+        expect(codes).toContain('NARROW_TIME_RANGE')
+      })
+
+      it('should emit RESTRICTIVE_SOURCE_FILTER when only source:alert is provided', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(emptyResponse)))
+
+        const result = await searchEventsV2(
+          apiV2,
+          {
+            query: 'source:alert',
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        const codes = result.diagnostics?.map((d) => d.code) ?? []
+        expect(codes).toContain('RESTRICTIVE_SOURCE_FILTER')
+      })
+
+      it('should NOT emit RESTRICTIVE_SOURCE_FILTER when other filters are present', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(emptyResponse)))
+
+        const result = await searchEventsV2(
+          apiV2,
+          {
+            query: 'source:alert env:prod',
+            tags: ['service:api'],
+            from: '2024-01-20T00:00:00Z',
+            to: '2024-01-20T23:59:59Z'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        const codes = result.diagnostics?.map((d) => d.code) ?? []
+        expect(codes).not.toContain('RESTRICTIVE_SOURCE_FILTER')
+      })
+
+      it('should set a remediation hint on each diagnostic', async () => {
+        server.use(http.post(endpoints.searchEvents, () => jsonResponse(emptyResponse)))
+
+        const result = await searchEventsV2(
+          apiV2,
+          {
+            query: 'source:alert monitor_priority:P1',
+            from: '2024-01-20T10:00:00Z',
+            to: '2024-01-20T10:02:00Z'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        for (const d of result.diagnostics ?? []) {
+          expect(typeof d.message).toBe('string')
+          expect(d.message.length).toBeGreaterThan(0)
+          expect(typeof d.hint).toBe('string')
+        }
+      })
+
+      it('should run computeDiagnostics in under 5ms on typical input', () => {
+        const input = {
+          query: 'source:alert monitor_priority:P1 env:prod',
+          tags: ['service:api', 'notification_preset:critical'],
+          fromMs: Date.parse('2024-01-20T10:00:00Z'),
+          toMs: Date.parse('2024-01-20T10:02:00Z')
+        }
+
+        const start = performance.now()
+        const diagnostics = computeDiagnostics(input)
+        const elapsed = performance.now() - start
+
+        expect(diagnostics.length).toBeGreaterThan(0)
+        expect(elapsed).toBeLessThan(5)
+      })
+
+      it('should expose the seed list of unindexed alert tag prefixes', () => {
+        expect(UNINDEXED_ALERT_TAG_PREFIXES).toEqual(
+          expect.arrayContaining(['monitor_priority', 'notification_preset'])
+        )
       })
     })
   })

--- a/tests/tools/events.test.ts
+++ b/tests/tools/events.test.ts
@@ -12,6 +12,7 @@ import {
   getEventV1,
   createEventV1,
   searchEventsV2,
+  histogramEventsV2,
   computeDiagnostics,
   UNINDEXED_ALERT_TAG_PREFIXES
 } from '../../src/tools/events.js'
@@ -22,7 +23,8 @@ const defaultLimits: LimitsConfig = {
   maxLogLines: 500,
   maxMetricDataPoints: 1000,
   defaultTimeRangeHours: 24,
-  defaultLimit: 100
+  defaultLimit: 100,
+  maxEventsForHistogram: 5000
 }
 
 const defaultSite = 'datadoghq.com'
@@ -555,6 +557,238 @@ describe('Events Tool', () => {
       // With a single value there must be no ` OR ` token inside the clause
       const clauseMatch = /@monitor\.transition\.transition_type:\(([^)]*)\)/.exec(query ?? '')
       expect(clauseMatch?.[1]).toBe('"alert recovery"')
+    })
+  })
+
+  describe('histogramEventsV2', () => {
+    const histogramRange = {
+      from: '2026-03-29T00:00:00Z',
+      to: '2026-03-29T23:59:59Z'
+    }
+
+    it('should return 24-bucket UTC happy path keyed 0-23', async () => {
+      server.use(
+        http.post(endpoints.searchEvents, () => jsonResponse(fixtures.eventsHistogramFixture))
+      )
+
+      const result = await histogramEventsV2(
+        apiV2,
+        {
+          bucket_by: 'hour_of_day',
+          timezone: 'UTC',
+          ...histogramRange
+        },
+        defaultLimits,
+        defaultSite
+      )
+
+      expect(result.bucketBy).toBe('hour_of_day')
+      expect(result.timezone).toBe('UTC')
+      // 4 events at UTC hours: 0, 1, 5, 23
+      expect(result.buckets).toEqual({
+        '0': 1,
+        '1': 1,
+        '5': 1,
+        '23': 1
+      })
+      expect(result.totalEvents).toBe(4)
+      expect(result.bucketCountIncomplete).toBeUndefined()
+      expect(result.nextCursor).toBeUndefined()
+      expect(result.meta.query).toBeDefined()
+      expect(result.meta.from).toBe('2026-03-29T00:00:00.000Z')
+      expect(result.meta.to).toBe('2026-03-29T23:59:59.000Z')
+      expect(result.meta.datadog_url).toContain('app.datadoghq.com')
+    })
+
+    it('should bucket DST spring-forward correctly in Europe/Paris', async () => {
+      // Europe/Paris spring-forward 2026-03-29: 02:00 local → 03:00 local.
+      // The DST-boundary event at 01:30 UTC lands at 03:30 local (hour 3),
+      // not 02:30 (which does not exist in local time on this day).
+      server.use(
+        http.post(endpoints.searchEvents, () => jsonResponse(fixtures.eventsHistogramFixture))
+      )
+
+      const result = await histogramEventsV2(
+        apiV2,
+        {
+          bucket_by: 'hour_of_day',
+          timezone: 'Europe/Paris',
+          ...histogramRange
+        },
+        defaultLimits,
+        defaultSite
+      )
+
+      // Paris-local hours for the four UTC events on 2026-03-29:
+      //   00:15 UTC → 01:15 local (CET, UTC+1) → bucket 1
+      //   01:30 UTC → 03:30 local (DST spring-forward) → bucket 3  ← key assertion
+      //   05:00 UTC → 07:00 local (CEST, UTC+2) → bucket 7
+      //   23:45 UTC → 01:45 local NEXT day (CEST) → bucket 1
+      expect(result.buckets['3']).toBe(1)
+      // The DST-skipped 02:00-02:59 local hour must contain zero events (or be absent).
+      expect(result.buckets['2'] ?? 0).toBe(0)
+      expect(result.totalEvents).toBe(4)
+    })
+
+    it('should throw EINVALID_TIMEZONE before hitting Datadog when timezone is invalid', async () => {
+      let datadogHit = false
+      server.use(
+        http.post(endpoints.searchEvents, () => {
+          datadogHit = true
+          return jsonResponse(fixtures.eventsHistogramFixture)
+        })
+      )
+
+      await expect(
+        histogramEventsV2(
+          apiV2,
+          {
+            bucket_by: 'hour_of_day',
+            timezone: 'Not/AZone',
+            ...histogramRange
+          },
+          defaultLimits,
+          defaultSite
+        )
+      ).rejects.toThrow(/EINVALID_TIMEZONE/)
+
+      expect(datadogHit).toBe(false)
+    })
+
+    it('should set bucketCountIncomplete and nextCursor when cap is reached', async () => {
+      // Build a fixture where every page returns the cap and a continuation cursor
+      // so the histogram loop must stop at the cap.
+      const page1Events = Array.from({ length: 3 }, (_, i) => ({
+        id: `evt-cap-${i}`,
+        attributes: {
+          title: `event ${i}`,
+          message: '',
+          timestamp: '2026-03-29T05:00:00.000Z',
+          tags: ['source:alert']
+        }
+      }))
+
+      server.use(
+        http.post(endpoints.searchEvents, () =>
+          jsonResponse({
+            data: page1Events,
+            meta: { page: { after: 'continuation-cursor-1' } }
+          })
+        )
+      )
+
+      const tightLimits: LimitsConfig = {
+        ...defaultLimits,
+        maxEventsForHistogram: 3
+      }
+
+      const result = await histogramEventsV2(
+        apiV2,
+        {
+          bucket_by: 'hour_of_day',
+          timezone: 'UTC',
+          ...histogramRange
+        },
+        tightLimits,
+        defaultSite
+      )
+
+      expect(result.totalEvents).toBe(3)
+      expect(result.bucketCountIncomplete).toBe(true)
+      expect(result.nextCursor).toBe('continuation-cursor-1')
+      expect(result.buckets['5']).toBe(3)
+    })
+
+    it('should support day_of_week bucketing', async () => {
+      server.use(
+        http.post(endpoints.searchEvents, () => jsonResponse(fixtures.eventsHistogramFixture))
+      )
+
+      const result = await histogramEventsV2(
+        apiV2,
+        {
+          bucket_by: 'day_of_week',
+          timezone: 'UTC',
+          ...histogramRange
+        },
+        defaultLimits,
+        defaultSite
+      )
+
+      // 2026-03-29 UTC is a Sunday → bucket 0 for all 4 fixture events.
+      expect(result.bucketBy).toBe('day_of_week')
+      expect(result.buckets['0']).toBe(4)
+      expect(result.totalEvents).toBe(4)
+    })
+
+    it('should support day_of_month bucketing', async () => {
+      server.use(
+        http.post(endpoints.searchEvents, () => jsonResponse(fixtures.eventsHistogramFixture))
+      )
+
+      const result = await histogramEventsV2(
+        apiV2,
+        {
+          bucket_by: 'day_of_month',
+          timezone: 'UTC',
+          ...histogramRange
+        },
+        defaultLimits,
+        defaultSite
+      )
+
+      // All fixture events fall on 2026-03-29 (UTC) → day-of-month 29.
+      expect(result.bucketBy).toBe('day_of_month')
+      expect(result.buckets['29']).toBe(4)
+      expect(result.totalEvents).toBe(4)
+    })
+
+    it('should default timezone to UTC when omitted', async () => {
+      server.use(
+        http.post(endpoints.searchEvents, () => jsonResponse(fixtures.eventsHistogramFixture))
+      )
+
+      const result = await histogramEventsV2(
+        apiV2,
+        {
+          bucket_by: 'hour_of_day',
+          ...histogramRange
+        },
+        defaultLimits,
+        defaultSite
+      )
+
+      expect(result.timezone).toBe('UTC')
+      expect(result.buckets['0']).toBe(1)
+      expect(result.buckets['1']).toBe(1)
+    })
+
+    it('should forward a supplied cursor as the first page cursor', async () => {
+      let observedCursor: string | undefined
+      server.use(
+        http.post(endpoints.searchEvents, async ({ request }) => {
+          const body = (await request.json()) as { page?: { cursor?: string } }
+          observedCursor = body.page?.cursor
+          return jsonResponse({
+            data: [],
+            meta: { page: { after: null } }
+          })
+        })
+      )
+
+      await histogramEventsV2(
+        apiV2,
+        {
+          bucket_by: 'hour_of_day',
+          timezone: 'UTC',
+          cursor: 'resume-from-here',
+          ...histogramRange
+        },
+        defaultLimits,
+        defaultSite
+      )
+
+      expect(observedCursor).toBe('resume-from-here')
     })
   })
 })

--- a/tests/tools/metrics.test.ts
+++ b/tests/tools/metrics.test.ts
@@ -11,7 +11,8 @@ import {
   queryMetrics,
   searchMetrics,
   listMetrics,
-  getMetricMetadata
+  getMetricMetadata,
+  parseRollupFromQuery
 } from '../../src/tools/metrics.js'
 import type { LimitsConfig } from '../../src/config/schema.js'
 
@@ -80,6 +81,222 @@ describe('Metrics Tool', () => {
         queryMetrics(api, { query: 'avg:system.cpu.user{*}' }, defaultLimits, defaultSite)
       ).rejects.toMatchObject({
         code: 401
+      })
+    })
+
+    describe('rollup override metadata', () => {
+      it('reports requested and effective rollup when intervals match', async () => {
+        server.use(
+          http.get(endpoints.queryMetrics, () => {
+            // Existing fixtures.query series uses 60s spacing (1705750800000, 1705750860000, ...)
+            return jsonResponse(fixtures.query)
+          })
+        )
+
+        const result = await queryMetrics(
+          api,
+          {
+            query: 'avg:system.cpu.user{*}.rollup(avg, 60)',
+            from: '1h',
+            to: 'now'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.meta.rollupRequested).toEqual({
+          interval: 60,
+          method: 'avg',
+          methodInferred: false
+        })
+        expect(result.meta.rollupEffective).toEqual({ interval: 60 })
+        expect(result.meta.rollupOverridden).toBe(false)
+      })
+
+      it('flags rollupOverridden=true when Datadog re-rolls the series', async () => {
+        server.use(
+          http.get(endpoints.queryMetrics, () => {
+            return jsonResponse(fixtures.queryRollupOverridden)
+          })
+        )
+
+        const result = await queryMetrics(
+          api,
+          {
+            query: 'avg:system.cpu.user{*}.rollup(sum, 900)',
+            from: '7d',
+            to: 'now'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.meta.rollupRequested).toEqual({
+          interval: 900,
+          method: 'sum',
+          methodInferred: false
+        })
+        expect(result.meta.rollupEffective).toEqual({ interval: 3600 })
+        expect(result.meta.rollupOverridden).toBe(true)
+      })
+
+      it('flags methodInferred=true when only the interval is given', async () => {
+        server.use(
+          http.get(endpoints.queryMetrics, () => {
+            return jsonResponse(fixtures.query)
+          })
+        )
+
+        const result = await queryMetrics(
+          api,
+          {
+            query: 'avg:system.cpu.user{*}.rollup(60)',
+            from: '1h',
+            to: 'now'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.meta.rollupRequested?.methodInferred).toBe(true)
+        expect(result.meta.rollupRequested?.interval).toBe(60)
+      })
+
+      it('returns intervalsObserved for multi-series with mixed intervals', async () => {
+        server.use(
+          http.get(endpoints.queryMetrics, () => {
+            return jsonResponse(fixtures.queryRollupMixedIntervals)
+          })
+        )
+
+        const result = await queryMetrics(
+          api,
+          {
+            query: 'avg:system.cpu.user{*}.rollup(avg, 900)',
+            from: '7d',
+            to: 'now'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.meta.rollupOverridden).toBe(true)
+        // `interval` echoes the first observed series interval; the full set is
+        // surfaced via `intervalsObserved` (deduped + sorted ascending).
+        expect(result.meta.rollupEffective?.interval).toBe(3600)
+        expect(result.meta.rollupEffective?.intervalsObserved).toEqual([900, 3600])
+      })
+
+      it('returns null rollupRequested for queries without rollup', async () => {
+        server.use(
+          http.get(endpoints.queryMetrics, () => {
+            return jsonResponse(fixtures.query)
+          })
+        )
+
+        const result = await queryMetrics(
+          api,
+          {
+            query: 'avg:system.cpu.user{*}',
+            from: '1h',
+            to: 'now'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.meta.rollupRequested).toBeNull()
+        expect(result.meta.rollupOverridden).toBe(false)
+      })
+
+      it('treats malformed rollup substring as no rollup', async () => {
+        server.use(
+          http.get(endpoints.queryMetrics, () => {
+            return jsonResponse(fixtures.query)
+          })
+        )
+
+        const result = await queryMetrics(
+          api,
+          {
+            query: 'avg:system.cpu.user{*}.rollup(garbage)',
+            from: '1h',
+            to: 'now'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.meta.rollupRequested).toBeNull()
+        expect(result.meta.rollupOverridden).toBe(false)
+      })
+
+      it('preserves existing top-level response keys', async () => {
+        server.use(
+          http.get(endpoints.queryMetrics, () => {
+            return jsonResponse(fixtures.query)
+          })
+        )
+
+        const result = await queryMetrics(
+          api,
+          {
+            query: 'avg:system.cpu.user{*}',
+            from: '1h',
+            to: 'now'
+          },
+          defaultLimits,
+          defaultSite
+        )
+
+        expect(result.series).toBeDefined()
+        expect(result.meta.query).toBe('avg:system.cpu.user{*}')
+        expect(result.meta.seriesCount).toBe(1)
+        expect(result.meta.datadog_url).toContain('app.datadoghq.com')
+      })
+    })
+  })
+
+  describe('parseRollupFromQuery', () => {
+    it('extracts method and interval from "rollup(sum, 900)"', () => {
+      expect(parseRollupFromQuery('avg:cpu{*}.rollup(sum, 900)')).toEqual({
+        interval: 900,
+        method: 'sum',
+        methodInferred: false
+      })
+    })
+
+    it('tolerates whitespace inside the rollup call', () => {
+      expect(parseRollupFromQuery('avg:cpu{*}.rollup( avg ,  60 )')).toEqual({
+        interval: 60,
+        method: 'avg',
+        methodInferred: false
+      })
+    })
+
+    it('defaults the method when only an interval is given', () => {
+      expect(parseRollupFromQuery('avg:cpu{*}.rollup(120)')).toEqual({
+        interval: 120,
+        method: 'avg',
+        methodInferred: true
+      })
+    })
+
+    it('returns null when the query has no rollup', () => {
+      expect(parseRollupFromQuery('avg:cpu{*}')).toBeNull()
+    })
+
+    it('returns null on malformed rollup substring', () => {
+      expect(parseRollupFromQuery('avg:cpu{*}.rollup(garbage)')).toBeNull()
+      expect(parseRollupFromQuery('avg:cpu{*}.rollup()')).toBeNull()
+      expect(parseRollupFromQuery('avg:cpu{*}.rollup(sum, nope)')).toBeNull()
+    })
+
+    it('handles nested expressions like default_zero().rollup(sum, 900)', () => {
+      expect(parseRollupFromQuery('default_zero(avg:cpu{*}).rollup(sum, 900).as_count()')).toEqual({
+        interval: 900,
+        method: 'sum',
+        methodInferred: false
       })
     })
   })

--- a/tests/tools/monitors.test.ts
+++ b/tests/tools/monitors.test.ts
@@ -945,4 +945,180 @@ describe('Monitors Tool', () => {
       expect(result.message).toContain('12345')
     })
   })
+
+  describe('monitors tool dispatcher — preview action', () => {
+    // Helper: capture the registered tool handler so we can invoke it directly,
+    // mirroring the dry_run dispatcher tests above.
+    type ToolHandler = (input: Record<string, unknown>) => Promise<unknown>
+    function captureHandler(readOnly: boolean): ToolHandler {
+      let capturedHandler: ToolHandler | null = null
+      const mockServer = {
+        tool: vi.fn(
+          (
+            _name: string,
+            _desc: string,
+            _schema: unknown,
+            handler: (input: Record<string, unknown>) => Promise<unknown>
+          ) => {
+            capturedHandler = handler
+          }
+        )
+      } as unknown as Parameters<typeof registerMonitorsTool>[0]
+
+      const eventsApi = {} as v2.EventsApi
+      registerMonitorsTool(mockServer, api, eventsApi, defaultLimits, readOnly, defaultSite)
+
+      if (!capturedHandler) {
+        throw new Error('Tool handler was not captured during registration')
+      }
+      return capturedHandler
+    }
+
+    type PreviewPayload = {
+      rendered: string
+      variablesUsed: string[]
+      variablesMissing: string[]
+      conditionalsResolved: Record<string, boolean>
+    }
+
+    function unwrap(result: unknown): PreviewPayload {
+      const typed = result as { content: { type: string; text: string }[] }
+      return JSON.parse(typed.content[0].text) as PreviewPayload
+    }
+
+    it('renders an inline message with variable substitution', async () => {
+      const handler = captureHandler(false)
+      const result = await handler({
+        action: 'preview',
+        message: 'CPU high on {{host.name}}',
+        context: { variables: { 'host.name': 'web-01' } }
+      })
+
+      const payload = unwrap(result)
+      expect(payload.rendered).toBe('CPU high on web-01')
+      expect(payload.variablesUsed).toContain('host.name')
+      expect(payload.variablesMissing).toEqual([])
+    })
+
+    it('loads template from monitor_id when no inline message is given', async () => {
+      let getCalls = 0
+      server.use(
+        http.get(endpoints.getMonitor(77777), () => {
+          getCalls++
+          return jsonResponse(fixtures.previewSource)
+        })
+      )
+
+      const handler = captureHandler(false)
+      const result = await handler({
+        action: 'preview',
+        monitor_id: 77777,
+        context: {
+          variables: { 'host.name': 'web-01' },
+          conditionals: { is_alert: true }
+        }
+      })
+
+      expect(getCalls).toBe(1)
+      const payload = unwrap(result)
+      expect(payload.rendered).toContain('CPU high on web-01')
+      expect(payload.rendered).toContain('ALERT branch')
+      expect(payload.rendered).not.toContain('OK branch')
+      expect(payload.conditionalsResolved.is_alert).toBe(true)
+    })
+
+    it('loads template from existing `id` field when monitor_id is omitted', async () => {
+      let getCalls = 0
+      server.use(
+        http.get(endpoints.getMonitor(77777), () => {
+          getCalls++
+          return jsonResponse(fixtures.previewSource)
+        })
+      )
+
+      const handler = captureHandler(false)
+      const result = await handler({
+        action: 'preview',
+        id: '77777',
+        context: { variables: { 'host.name': 'web-02' } }
+      })
+
+      expect(getCalls).toBe(1)
+      const payload = unwrap(result)
+      expect(payload.rendered).toContain('CPU high on web-02')
+    })
+
+    it('reports missing variables with the {{undefined:name}} marker', async () => {
+      const handler = captureHandler(false)
+      const result = await handler({
+        action: 'preview',
+        message: 'Host: {{host.name}} pod: {{pod.name}}',
+        context: { variables: { 'host.name': 'web-01' } }
+      })
+
+      const payload = unwrap(result)
+      expect(payload.rendered).toBe('Host: web-01 pod: {{undefined:pod.name}}')
+      expect(payload.variablesMissing).toContain('pod.name')
+      expect(payload.variablesUsed).toContain('host.name')
+    })
+
+    it('resolves a conditional as truthy when set true in context', async () => {
+      const handler = captureHandler(false)
+      const result = await handler({
+        action: 'preview',
+        message: 'Status: {{#is_alert}}ALERT{{/is_alert}}{{^is_alert}}OK{{/is_alert}}',
+        context: { conditionals: { is_alert: true } }
+      })
+
+      const payload = unwrap(result)
+      expect(payload.rendered).toBe('Status: ALERT')
+      expect(payload.conditionalsResolved.is_alert).toBe(true)
+    })
+
+    it('resolves a conditional as falsy when set false (or omitted) in context', async () => {
+      const handler = captureHandler(false)
+      const result = await handler({
+        action: 'preview',
+        message: 'Status: {{#is_warning}}WARN{{/is_warning}}{{^is_warning}}OK{{/is_warning}}',
+        context: { conditionals: { is_warning: false } }
+      })
+
+      const payload = unwrap(result)
+      expect(payload.rendered).toBe('Status: OK')
+      expect(payload.conditionalsResolved.is_warning).toBe(false)
+    })
+
+    it('returns EUNSUPPORTED_TEMPLATE_SYNTAX for {{#each}} loops', async () => {
+      const handler = captureHandler(false)
+      await expect(
+        handler({
+          action: 'preview',
+          message: '{{#each items}}item{{/each}}',
+          context: {}
+        })
+      ).rejects.toThrow(/EUNSUPPORTED_TEMPLATE_SYNTAX/)
+    })
+
+    it('requires either message or a monitor id', async () => {
+      const handler = captureHandler(false)
+      await expect(
+        handler({
+          action: 'preview',
+          context: {}
+        })
+      ).rejects.toThrow(/message.*monitor_id|monitor_id.*message|required/i)
+    })
+
+    it('is allowed in read-only mode (preview is non-mutating)', async () => {
+      const handler = captureHandler(true)
+      const result = await handler({
+        action: 'preview',
+        message: 'hello {{name}}',
+        context: { variables: { name: 'world' } }
+      })
+
+      const payload = unwrap(result)
+      expect(payload.rendered).toBe('hello world')
+    })
+  })
 })

--- a/tests/tools/monitors.test.ts
+++ b/tests/tools/monitors.test.ts
@@ -1275,4 +1275,128 @@ describe('Monitors Tool', () => {
       })
     })
   })
+
+  // Requirement 6 — `test_notification` action.
+  // OQ-1 closed during Task 8 research: the Datadog public REST API exposes no
+  // `POST /api/v1/monitor/{id}/notify` (or `/test`) endpoint at v1 or v2. The
+  // full list of monitor paths in the official OpenAPI specs is documented in
+  // the JSDoc on `testNotificationMonitor` in src/tools/monitors.ts. Per
+  // design.md "Open questions OQ-1" and Requirement 6 AC2, the action surfaces
+  // an explicit `ENOT_SUPPORTED` error and performs no Datadog HTTP call.
+  describe('monitors tool dispatcher — test_notification action (Requirement 6)', () => {
+    type ToolHandler = (input: Record<string, unknown>) => Promise<unknown>
+
+    function captureHandler(readOnly: boolean): ToolHandler {
+      let capturedHandler: ToolHandler | null = null
+      const mockServer = {
+        tool: vi.fn(
+          (
+            _name: string,
+            _desc: string,
+            _schema: unknown,
+            handler: (input: Record<string, unknown>) => Promise<unknown>
+          ) => {
+            capturedHandler = handler
+          }
+        )
+      } as unknown as Parameters<typeof registerMonitorsTool>[0]
+
+      const eventsApi = {} as v2.EventsApi
+      registerMonitorsTool(mockServer, api, eventsApi, defaultLimits, readOnly, defaultSite)
+
+      if (!capturedHandler) {
+        throw new Error('Tool handler was not captured during registration')
+      }
+      return capturedHandler
+    }
+
+    it('returns ENOT_SUPPORTED with a documentation pointer and never calls Datadog', async () => {
+      // Install handlers on every monitor path; any hit fails the assertion.
+      let anyHit = 0
+      server.use(
+        http.post(`${endpoints.getMonitor(12345)}/notify`, () => {
+          anyHit++
+          return jsonResponse({})
+        }),
+        http.post(`${endpoints.getMonitor(12345)}/test`, () => {
+          anyHit++
+          return jsonResponse({})
+        }),
+        http.get(endpoints.getMonitor(12345), () => {
+          anyHit++
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      const handler = captureHandler(false)
+      await expect(
+        handler({
+          action: 'test_notification',
+          monitor_id: 12345
+        })
+      ).rejects.toThrow(/ENOT_SUPPORTED/)
+      expect(anyHit).toBe(0)
+    })
+
+    it('error message cites the Datadog API docs URL so callers can verify the limitation', async () => {
+      const handler = captureHandler(false)
+      await expect(
+        handler({
+          action: 'test_notification',
+          monitor_id: 12345
+        })
+      ).rejects.toThrow(/docs\.datadoghq\.com\/api\/latest\/monitors/)
+    })
+
+    it('requires a monitor_id (or `id`) — missing identifier returns ENOT_SUPPORTED, not a vague error', async () => {
+      // Even without an id we must return ENOT_SUPPORTED rather than silently
+      // succeed or throw a generic "invalid params" error. The capability is
+      // unsupported regardless of inputs.
+      const handler = captureHandler(false)
+      await expect(
+        handler({
+          action: 'test_notification'
+        })
+      ).rejects.toThrow(/ENOT_SUPPORTED/)
+    })
+
+    it('accepts the existing stringly-typed `id` field as monitor identifier', async () => {
+      let anyHit = 0
+      server.use(
+        http.post(`${endpoints.getMonitor(12345)}/notify`, () => {
+          anyHit++
+          return jsonResponse({})
+        })
+      )
+
+      const handler = captureHandler(false)
+      await expect(
+        handler({
+          action: 'test_notification',
+          id: '12345'
+        })
+      ).rejects.toThrow(/ENOT_SUPPORTED/)
+      expect(anyHit).toBe(0)
+    })
+
+    it('is allowed in read-only mode (test_notification is not a write action)', async () => {
+      // Per Requirement 6 AC4: read-only must allow the action. The reason it
+      // ends in ENOT_SUPPORTED is the API limitation, NOT a readOnly block.
+      const handler = captureHandler(true)
+      await expect(
+        handler({
+          action: 'test_notification',
+          monitor_id: 12345
+        })
+      ).rejects.toThrow(/ENOT_SUPPORTED/)
+      // Critically, the rejection must NOT mention "read-only" — that would
+      // mean the dispatcher blocked it before reaching the action handler.
+      await expect(
+        handler({
+          action: 'test_notification',
+          monitor_id: 12345
+        })
+      ).rejects.not.toThrow(/read-only/)
+    })
+  })
 })

--- a/tests/tools/monitors.test.ts
+++ b/tests/tools/monitors.test.ts
@@ -1121,4 +1121,158 @@ describe('Monitors Tool', () => {
       expect(payload.rendered).toBe('hello world')
     })
   })
+
+  // Requirement 4 (timezone annotation) — opt-in `timezone` param on
+  // monitors.get / monitors.list adds `createdLocal` / `modifiedLocal` siblings.
+  // Omitting `timezone` produces today's exact response shape.
+  describe('monitors read actions — timezone annotation (Requirement 4)', () => {
+    describe('getMonitor', () => {
+      it('adds createdLocal and modifiedLocal next to created/modified when timezone is provided', async () => {
+        server.use(http.get(endpoints.getMonitor(12345), () => jsonResponse(fixtures.single)))
+
+        const result = await getMonitor(api, '12345', defaultSite, 'Europe/Paris')
+
+        expect(result.monitor.created).toBe('2024-01-15T10:00:00.000Z')
+        // 2024-01-15T10:00:00Z in Europe/Paris (CET = UTC+1) → 11:00 local
+        expect(result.monitor.createdLocal).toBe('2024-01-15T11:00:00+01:00')
+        // 2024-01-20T15:30:00Z in Europe/Paris (CET = UTC+1) → 16:30 local
+        expect(result.monitor.modifiedLocal).toBe('2024-01-20T16:30:00+01:00')
+      })
+
+      it('does NOT add *Local fields when timezone is omitted', async () => {
+        server.use(http.get(endpoints.getMonitor(12345), () => jsonResponse(fixtures.single)))
+
+        const result = await getMonitor(api, '12345', defaultSite)
+
+        expect(Object.prototype.hasOwnProperty.call(result.monitor, 'createdLocal')).toBe(false)
+        expect(Object.prototype.hasOwnProperty.call(result.monitor, 'modifiedLocal')).toBe(false)
+      })
+
+      it('throws EINVALID_TIMEZONE without calling Datadog when timezone is invalid', async () => {
+        let hit = false
+        server.use(
+          http.get(endpoints.getMonitor(12345), () => {
+            hit = true
+            return jsonResponse(fixtures.single)
+          })
+        )
+
+        await expect(getMonitor(api, '12345', defaultSite, 'Not/AZone')).rejects.toThrow(
+          /EINVALID_TIMEZONE/
+        )
+        expect(hit).toBe(false)
+      })
+    })
+
+    describe('listMonitors', () => {
+      it('adds createdLocal and modifiedLocal on every monitor when timezone is provided', async () => {
+        server.use(http.get(endpoints.listMonitors, () => jsonResponse(fixtures.list)))
+
+        const result = await listMonitors(api, {}, defaultLimits, defaultSite, 'Europe/Paris')
+
+        expect(result.monitors.length).toBeGreaterThan(0)
+        for (const monitor of result.monitors) {
+          expect(typeof monitor.createdLocal).toBe('string')
+          expect(typeof monitor.modifiedLocal).toBe('string')
+          expect(monitor.createdLocal).toMatch(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([+-]\d{2}:\d{2}|Z)$/
+          )
+        }
+      })
+
+      it('does NOT add *Local fields on monitors when timezone is omitted', async () => {
+        server.use(http.get(endpoints.listMonitors, () => jsonResponse(fixtures.list)))
+
+        const result = await listMonitors(api, {}, defaultLimits, defaultSite)
+
+        for (const monitor of result.monitors) {
+          expect(Object.prototype.hasOwnProperty.call(monitor, 'createdLocal')).toBe(false)
+          expect(Object.prototype.hasOwnProperty.call(monitor, 'modifiedLocal')).toBe(false)
+        }
+      })
+
+      it('throws EINVALID_TIMEZONE without calling Datadog when timezone is invalid', async () => {
+        let hit = false
+        server.use(
+          http.get(endpoints.listMonitors, () => {
+            hit = true
+            return jsonResponse(fixtures.list)
+          })
+        )
+
+        await expect(
+          listMonitors(api, {}, defaultLimits, defaultSite, 'Not/AZone')
+        ).rejects.toThrow(/EINVALID_TIMEZONE/)
+        expect(hit).toBe(false)
+      })
+    })
+
+    describe('dispatcher — timezone plumbing', () => {
+      type ToolHandler = (input: Record<string, unknown>) => Promise<unknown>
+
+      function captureHandler(readOnly: boolean): ToolHandler {
+        let capturedHandler: ToolHandler | null = null
+        const mockServer = {
+          tool: vi.fn(
+            (
+              _name: string,
+              _desc: string,
+              _schema: unknown,
+              handler: (input: Record<string, unknown>) => Promise<unknown>
+            ) => {
+              capturedHandler = handler
+            }
+          )
+        } as unknown as Parameters<typeof registerMonitorsTool>[0]
+
+        const eventsApi = {} as v2.EventsApi
+        registerMonitorsTool(mockServer, api, eventsApi, defaultLimits, readOnly, defaultSite)
+
+        if (!capturedHandler) {
+          throw new Error('Tool handler was not captured during registration')
+        }
+        return capturedHandler
+      }
+
+      function unwrapJson<T>(result: unknown): T {
+        const typed = result as { content: { type: string; text: string }[] }
+        return JSON.parse(typed.content[0].text) as T
+      }
+
+      it('threads `timezone` through monitors.get and emits *Local fields', async () => {
+        server.use(http.get(endpoints.getMonitor(12345), () => jsonResponse(fixtures.single)))
+
+        const handler = captureHandler(false)
+        const result = await handler({
+          action: 'get',
+          id: '12345',
+          timezone: 'Europe/Paris'
+        })
+
+        const payload = unwrapJson<{ monitor: { createdLocal?: string; modifiedLocal?: string } }>(
+          result
+        )
+        expect(payload.monitor.createdLocal).toBe('2024-01-15T11:00:00+01:00')
+        expect(payload.monitor.modifiedLocal).toBe('2024-01-20T16:30:00+01:00')
+      })
+
+      it('threads `timezone` through monitors.list and emits *Local fields', async () => {
+        server.use(http.get(endpoints.listMonitors, () => jsonResponse(fixtures.list)))
+
+        const handler = captureHandler(false)
+        const result = await handler({
+          action: 'list',
+          timezone: 'Europe/Paris'
+        })
+
+        const payload = unwrapJson<{
+          monitors: Array<{ createdLocal?: string; modifiedLocal?: string }>
+        }>(result)
+        for (const m of payload.monitors) {
+          expect(typeof m.createdLocal).toBe('string')
+          expect(typeof m.modifiedLocal).toBe('string')
+        }
+      })
+    })
+  })
 })

--- a/tests/tools/monitors.test.ts
+++ b/tests/tools/monitors.test.ts
@@ -1,8 +1,8 @@
 /**
  * Unit tests for the monitors tool
  */
-import { describe, it, expect, beforeEach } from 'vitest'
-import { v1 } from '@datadog/datadog-api-client'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { v1, v2 } from '@datadog/datadog-api-client'
 import { http } from 'msw'
 import { server, endpoints, jsonResponse, errorResponse } from '../helpers/msw.js'
 import { createMockConfig } from '../helpers/mock.js'
@@ -12,8 +12,10 @@ import {
   getMonitor,
   searchMonitors,
   createMonitor,
+  dryRunMonitor,
   updateMonitor,
-  deleteMonitor
+  deleteMonitor,
+  registerMonitorsTool
 } from '../../src/tools/monitors.js'
 import type { LimitsConfig } from '../../src/config/schema.js'
 
@@ -279,6 +281,266 @@ describe('Monitors Tool', () => {
       await expect(createMonitor(api, validConfig)).rejects.toMatchObject({
         code: 400
       })
+    })
+  })
+
+  describe('dryRunMonitor', () => {
+    it('should call POST /api/v1/monitor/validate and return { valid: true, dryRun: true, monitor }', async () => {
+      const newMonitor = {
+        name: 'Validated Monitor',
+        type: 'metric alert',
+        query: 'avg(last_5m):avg:system.cpu.user{*} > 95',
+        message: 'CPU high'
+      }
+
+      let receivedBody: unknown = null
+      let createCallCount = 0
+      server.use(
+        http.post(endpoints.validateMonitor, async ({ request }) => {
+          receivedBody = await request.json()
+          return jsonResponse(fixtures.validateOk)
+        }),
+        http.post(endpoints.listMonitors, () => {
+          createCallCount++
+          return jsonResponse({ id: 99999 })
+        })
+      )
+
+      const result = await dryRunMonitor(api, newMonitor)
+
+      expect(result.valid).toBe(true)
+      expect(result.dryRun).toBe(true)
+      expect(result.monitor).toMatchObject({
+        name: 'Validated Monitor',
+        type: 'metric alert',
+        query: 'avg(last_5m):avg:system.cpu.user{*} > 95'
+      })
+      // The body sent to validate matches the normalized config
+      expect(receivedBody).toMatchObject({
+        name: 'Validated Monitor',
+        type: 'metric alert',
+        query: 'avg(last_5m):avg:system.cpu.user{*} > 95'
+      })
+      // Confirms validate was called, not create
+      expect(createCallCount).toBe(0)
+    })
+
+    it('should pass through 400 errors from validateMonitor via handleDatadogError', async () => {
+      server.use(
+        http.post(endpoints.validateMonitor, () => {
+          return errorResponse(400, 'The value provided for parameter "query" is invalid')
+        })
+      )
+
+      const invalidConfig = {
+        name: 'Bad Monitor',
+        type: 'metric alert',
+        query: 'this is not a valid query'
+      }
+
+      await expect(dryRunMonitor(api, invalidConfig)).rejects.toMatchObject({
+        code: 400
+      })
+    })
+
+    it('should validate required fields before calling validateMonitor', async () => {
+      // Reuses normalizeMonitorConfig validation — empty body must throw before network
+      let validateCalled = 0
+      server.use(
+        http.post(endpoints.validateMonitor, () => {
+          validateCalled++
+          return jsonResponse(fixtures.validateOk)
+        })
+      )
+
+      await expect(dryRunMonitor(api, {})).rejects.toThrow(/requires at least/)
+      expect(validateCalled).toBe(0)
+    })
+  })
+
+  describe('monitors tool dispatcher — dry_run + read-only', () => {
+    // Helper: capture the registered tool handler so we can invoke it directly.
+    type ToolHandler = (input: Record<string, unknown>) => Promise<unknown>
+    function captureHandler(readOnly: boolean): ToolHandler {
+      let capturedHandler: ToolHandler | null = null
+      const mockServer = {
+        tool: vi.fn(
+          (
+            _name: string,
+            _desc: string,
+            _schema: unknown,
+            handler: (input: Record<string, unknown>) => Promise<unknown>
+          ) => {
+            capturedHandler = handler
+          }
+        )
+      } as unknown as Parameters<typeof registerMonitorsTool>[0]
+
+      const eventsApi = {} as v2.EventsApi
+      registerMonitorsTool(mockServer, api, eventsApi, defaultLimits, readOnly, defaultSite)
+
+      if (!capturedHandler) {
+        throw new Error('Tool handler was not captured during registration')
+      }
+      return capturedHandler
+    }
+
+    it('allows action=create with dry_run=true in read-only mode (routes to validateMonitor)', async () => {
+      let validateCalled = 0
+      let createCalled = 0
+      server.use(
+        http.post(endpoints.validateMonitor, () => {
+          validateCalled++
+          return jsonResponse(fixtures.validateOk)
+        }),
+        http.post(endpoints.listMonitors, () => {
+          createCalled++
+          return jsonResponse({ id: 1 })
+        })
+      )
+
+      const handler = captureHandler(true)
+      const result = (await handler({
+        action: 'create',
+        dry_run: true,
+        config: {
+          name: 'Dry Run Monitor',
+          type: 'metric alert',
+          query: 'avg(last_5m):avg:system.cpu.user{*} > 95'
+        }
+      })) as { content: { type: string; text: string }[] }
+
+      expect(validateCalled).toBe(1)
+      expect(createCalled).toBe(0)
+      const payload = JSON.parse(result.content[0].text) as {
+        valid: boolean
+        dryRun: boolean
+        monitor: Record<string, unknown>
+      }
+      expect(payload.valid).toBe(true)
+      expect(payload.dryRun).toBe(true)
+      expect(payload.monitor.name).toBe('Dry Run Monitor')
+    })
+
+    it('blocks action=create with dry_run=false in read-only mode', async () => {
+      let createCalled = 0
+      server.use(
+        http.post(endpoints.listMonitors, () => {
+          createCalled++
+          return jsonResponse({ id: 1 })
+        })
+      )
+
+      const handler = captureHandler(true)
+      // handleDatadogError throws — the tool catches and rethrows McpError. The handler
+      // re-raises via handleDatadogError which throws an McpError; assert it propagates.
+      await expect(
+        handler({
+          action: 'create',
+          dry_run: false,
+          config: {
+            name: 'Blocked Monitor',
+            type: 'metric alert',
+            query: 'avg(last_5m):avg:system.cpu.user{*} > 1'
+          }
+        })
+      ).rejects.toThrow(/read-only mode/)
+      expect(createCalled).toBe(0)
+    })
+
+    it('blocks action=create with dry_run omitted in read-only mode', async () => {
+      let createCalled = 0
+      server.use(
+        http.post(endpoints.listMonitors, () => {
+          createCalled++
+          return jsonResponse({ id: 1 })
+        })
+      )
+
+      const handler = captureHandler(true)
+      await expect(
+        handler({
+          action: 'create',
+          config: {
+            name: 'Blocked Monitor',
+            type: 'metric alert',
+            query: 'avg(last_5m):avg:system.cpu.user{*} > 1'
+          }
+        })
+      ).rejects.toThrow(/read-only mode/)
+      expect(createCalled).toBe(0)
+    })
+
+    it('with dry_run omitted and not read-only, preserves existing create behavior', async () => {
+      let validateCalled = 0
+      let createCalled = 0
+      server.use(
+        http.post(endpoints.validateMonitor, () => {
+          validateCalled++
+          return jsonResponse(fixtures.validateOk)
+        }),
+        http.post(endpoints.listMonitors, async ({ request }) => {
+          createCalled++
+          const body = (await request.json()) as Record<string, unknown>
+          return jsonResponse({
+            id: 12347,
+            ...body,
+            overall_state: 'No Data',
+            created: new Date().toISOString(),
+            modified: new Date().toISOString()
+          })
+        })
+      )
+
+      const handler = captureHandler(false)
+      const result = (await handler({
+        action: 'create',
+        config: {
+          name: 'Real Create',
+          type: 'metric alert',
+          query: 'avg(last_5m):avg:system.cpu.user{*} > 95'
+        }
+      })) as { content: { type: string; text: string }[] }
+
+      expect(validateCalled).toBe(0)
+      expect(createCalled).toBe(1)
+      const payload = JSON.parse(result.content[0].text) as {
+        success: boolean
+        monitor: { id: number }
+      }
+      expect(payload.success).toBe(true)
+      expect(payload.monitor.id).toBe(12347)
+    })
+
+    it('with dry_run=true and not read-only, still routes to validateMonitor (no create)', async () => {
+      let validateCalled = 0
+      let createCalled = 0
+      server.use(
+        http.post(endpoints.validateMonitor, () => {
+          validateCalled++
+          return jsonResponse(fixtures.validateOk)
+        }),
+        http.post(endpoints.listMonitors, () => {
+          createCalled++
+          return jsonResponse({ id: 1 })
+        })
+      )
+
+      const handler = captureHandler(false)
+      const result = (await handler({
+        action: 'create',
+        dry_run: true,
+        config: {
+          name: 'Dry Run',
+          type: 'metric alert',
+          query: 'avg(last_5m):avg:system.cpu.user{*} > 95'
+        }
+      })) as { content: { type: string; text: string }[] }
+
+      expect(validateCalled).toBe(1)
+      expect(createCalled).toBe(0)
+      const payload = JSON.parse(result.content[0].text) as { dryRun: boolean }
+      expect(payload.dryRun).toBe(true)
     })
   })
 

--- a/tests/tools/schema.test.ts
+++ b/tests/tools/schema.test.ts
@@ -116,6 +116,22 @@ describe('schema tool', () => {
       expect(result.schema.timeframes).toContain('30d')
       expect(result.schema.timeframes).toContain('90d')
     })
+
+    it('should return events schema with diagnosticCodes', () => {
+      const result = getSchema('events')
+
+      expect(result.resource).toBe('events')
+      expect(result.schema).toHaveProperty('diagnosticCodes')
+      expect(result.schema).toHaveProperty('docsUrl')
+    })
+
+    it('should expose the three zero-result diagnostic codes', () => {
+      const result = getSchema('events')
+
+      expect(result.schema.diagnosticCodes).toContain('UNINDEXED_TAG_PREFIX')
+      expect(result.schema.diagnosticCodes).toContain('NARROW_TIME_RANGE')
+      expect(result.schema.diagnosticCodes).toContain('RESTRICTIVE_SOURCE_FILTER')
+    })
   })
 
   describe('registerSchemaTool', () => {
@@ -183,6 +199,18 @@ describe('schema tool', () => {
 
       expect(result.content[0].text).toContain('slos')
       expect(result.content[0].text).toContain('timeframes')
+    })
+
+    it('should return events schema via registered handler', async () => {
+      registerSchemaTool(mockServer)
+
+      const result = (await registeredHandler({ resource: 'events' })) as {
+        content: { text: string }[]
+      }
+
+      expect(result.content[0].text).toContain('events')
+      expect(result.content[0].text).toContain('diagnosticCodes')
+      expect(result.content[0].text).toContain('UNINDEXED_TAG_PREFIX')
     })
   })
 })

--- a/tests/utils/templatePreview.test.ts
+++ b/tests/utils/templatePreview.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from 'vitest'
+import { renderMonitorTemplate } from '../../src/utils/templatePreview.js'
+
+describe('renderMonitorTemplate', () => {
+  describe('variable substitution', () => {
+    it('substitutes a simple top-level variable', () => {
+      const result = renderMonitorTemplate('Hello {{name}}', { variables: { name: 'world' } })
+
+      expect(result.rendered).toBe('Hello world')
+      expect(result.variablesUsed).toEqual(['name'])
+      expect(result.variablesMissing).toEqual([])
+    })
+
+    it('substitutes nested variables via dot-notation', () => {
+      const result = renderMonitorTemplate('Service: {{service.name}}', {
+        variables: { 'service.name': 'api-gateway' }
+      })
+
+      expect(result.rendered).toBe('Service: api-gateway')
+      expect(result.variablesUsed).toEqual(['service.name'])
+    })
+
+    it('substitutes deep nested variables when context is a nested object', () => {
+      const result = renderMonitorTemplate('Host: {{host.tags.region}}', {
+        variables: { host: { tags: { region: 'eu-west-1' } } } as unknown as Record<string, string>
+      })
+
+      expect(result.rendered).toBe('Host: eu-west-1')
+      expect(result.variablesUsed).toEqual(['host.tags.region'])
+    })
+
+    it('substitutes multiple variables in one template', () => {
+      const result = renderMonitorTemplate('{{a}} and {{b}}', {
+        variables: { a: 'foo', b: 'bar' }
+      })
+
+      expect(result.rendered).toBe('foo and bar')
+      expect(result.variablesUsed.sort()).toEqual(['a', 'b'])
+    })
+
+    it('marks a missing variable as {{undefined:name}} and reports it', () => {
+      const result = renderMonitorTemplate('Hello {{missing}}', { variables: {} })
+
+      expect(result.rendered).toBe('Hello {{undefined:missing}}')
+      expect(result.variablesMissing).toEqual(['missing'])
+      expect(result.variablesUsed).toEqual([])
+    })
+
+    it('marks a variable not present in context.variables (no variables key) as undefined', () => {
+      const result = renderMonitorTemplate('Value: {{x}}', {})
+
+      expect(result.rendered).toBe('Value: {{undefined:x}}')
+      expect(result.variablesMissing).toEqual(['x'])
+    })
+
+    it('handles a variable that appears multiple times only once in variablesUsed', () => {
+      const result = renderMonitorTemplate('{{x}} {{x}} {{x}}', {
+        variables: { x: 'a' }
+      })
+
+      expect(result.rendered).toBe('a a a')
+      expect(result.variablesUsed).toEqual(['x'])
+    })
+
+    it('handles whitespace inside the mustache braces', () => {
+      const result = renderMonitorTemplate('{{ name }}', { variables: { name: 'ok' } })
+
+      expect(result.rendered).toBe('ok')
+      expect(result.variablesUsed).toEqual(['name'])
+    })
+  })
+
+  describe('conditional blocks — positive', () => {
+    it('renders {{#is_alert}} block when is_alert is true', () => {
+      const result = renderMonitorTemplate('{{#is_alert}}ALERT{{/is_alert}}', {
+        conditionals: { is_alert: true }
+      })
+
+      expect(result.rendered).toBe('ALERT')
+      expect(result.conditionalsResolved).toEqual({ is_alert: true })
+    })
+
+    it('drops {{#is_alert}} block when is_alert is false', () => {
+      const result = renderMonitorTemplate('before {{#is_alert}}ALERT{{/is_alert}} after', {
+        conditionals: { is_alert: false }
+      })
+
+      expect(result.rendered).toBe('before  after')
+      expect(result.conditionalsResolved).toEqual({ is_alert: false })
+    })
+
+    it('drops {{#is_alert}} block when is_alert is missing (default false)', () => {
+      const result = renderMonitorTemplate('before {{#is_alert}}ALERT{{/is_alert}} after', {})
+
+      expect(result.rendered).toBe('before  after')
+      expect(result.conditionalsResolved).toEqual({ is_alert: false })
+    })
+
+    it('supports is_warning', () => {
+      const result = renderMonitorTemplate('{{#is_warning}}W{{/is_warning}}', {
+        conditionals: { is_warning: true }
+      })
+
+      expect(result.rendered).toBe('W')
+      expect(result.conditionalsResolved).toEqual({ is_warning: true })
+    })
+
+    it('supports is_no_data', () => {
+      const result = renderMonitorTemplate('{{#is_no_data}}NODATA{{/is_no_data}}', {
+        conditionals: { is_no_data: true }
+      })
+
+      expect(result.rendered).toBe('NODATA')
+      expect(result.conditionalsResolved).toEqual({ is_no_data: true })
+    })
+
+    it('supports is_recovery', () => {
+      const result = renderMonitorTemplate('{{#is_recovery}}REC{{/is_recovery}}', {
+        conditionals: { is_recovery: true }
+      })
+
+      expect(result.rendered).toBe('REC')
+      expect(result.conditionalsResolved).toEqual({ is_recovery: true })
+    })
+
+    it('supports is_alert_to_warning', () => {
+      const result = renderMonitorTemplate('{{#is_alert_to_warning}}A2W{{/is_alert_to_warning}}', {
+        conditionals: { is_alert_to_warning: true }
+      })
+
+      expect(result.rendered).toBe('A2W')
+      expect(result.conditionalsResolved).toEqual({ is_alert_to_warning: true })
+    })
+
+    it('supports is_warning_to_alert', () => {
+      const result = renderMonitorTemplate('{{#is_warning_to_alert}}W2A{{/is_warning_to_alert}}', {
+        conditionals: { is_warning_to_alert: true }
+      })
+
+      expect(result.rendered).toBe('W2A')
+      expect(result.conditionalsResolved).toEqual({ is_warning_to_alert: true })
+    })
+  })
+
+  describe('conditional blocks — negation', () => {
+    it('renders {{^is_warning}} block when is_warning is false', () => {
+      const result = renderMonitorTemplate('{{^is_warning}}NOTW{{/is_warning}}', {
+        conditionals: { is_warning: false }
+      })
+
+      expect(result.rendered).toBe('NOTW')
+      expect(result.conditionalsResolved).toEqual({ is_warning: false })
+    })
+
+    it('renders {{^is_warning}} block when is_warning is missing (default false)', () => {
+      const result = renderMonitorTemplate('{{^is_warning}}NOTW{{/is_warning}}', {})
+
+      expect(result.rendered).toBe('NOTW')
+      expect(result.conditionalsResolved).toEqual({ is_warning: false })
+    })
+
+    it('drops {{^is_warning}} block when is_warning is true', () => {
+      const result = renderMonitorTemplate('before {{^is_warning}}NOTW{{/is_warning}} after', {
+        conditionals: { is_warning: true }
+      })
+
+      expect(result.rendered).toBe('before  after')
+      expect(result.conditionalsResolved).toEqual({ is_warning: true })
+    })
+
+    it('supports negation for all 6 conditionals', () => {
+      const conditionals: Array<
+        | 'is_alert'
+        | 'is_warning'
+        | 'is_no_data'
+        | 'is_recovery'
+        | 'is_alert_to_warning'
+        | 'is_warning_to_alert'
+      > = [
+        'is_alert',
+        'is_warning',
+        'is_no_data',
+        'is_recovery',
+        'is_alert_to_warning',
+        'is_warning_to_alert'
+      ]
+
+      for (const cond of conditionals) {
+        const result = renderMonitorTemplate(`{{^${cond}}}X{{/${cond}}}`, {})
+        expect(result.rendered).toBe('X')
+        expect(result.conditionalsResolved[cond]).toBe(false)
+      }
+    })
+  })
+
+  describe('nested and mixed', () => {
+    it('handles a variable inside a conditional block', () => {
+      const result = renderMonitorTemplate('{{#is_alert}}Alert on {{service}}{{/is_alert}}', {
+        variables: { service: 'api' },
+        conditionals: { is_alert: true }
+      })
+
+      expect(result.rendered).toBe('Alert on api')
+      expect(result.variablesUsed).toEqual(['service'])
+      expect(result.conditionalsResolved).toEqual({ is_alert: true })
+    })
+
+    it('does not collect variables from a dropped conditional block', () => {
+      const result = renderMonitorTemplate('static {{#is_alert}}{{service}}{{/is_alert}}', {
+        variables: { service: 'api' },
+        conditionals: { is_alert: false }
+      })
+
+      expect(result.rendered).toBe('static ')
+      expect(result.variablesUsed).toEqual([])
+      expect(result.variablesMissing).toEqual([])
+    })
+
+    it('handles nested conditional inside another conditional', () => {
+      const tpl = '{{#is_alert}}A{{#is_warning}}W{{/is_warning}}E{{/is_alert}}'
+      const result = renderMonitorTemplate(tpl, {
+        conditionals: { is_alert: true, is_warning: true }
+      })
+
+      expect(result.rendered).toBe('AWE')
+      expect(result.conditionalsResolved).toEqual({ is_alert: true, is_warning: true })
+    })
+
+    it('drops nested conditional when inner is false', () => {
+      const tpl = '{{#is_alert}}A{{#is_warning}}W{{/is_warning}}E{{/is_alert}}'
+      const result = renderMonitorTemplate(tpl, {
+        conditionals: { is_alert: true, is_warning: false }
+      })
+
+      expect(result.rendered).toBe('AE')
+      expect(result.conditionalsResolved).toEqual({ is_alert: true, is_warning: false })
+    })
+
+    it('drops outer conditional regardless of inner conditional', () => {
+      const tpl = '{{#is_alert}}A{{#is_warning}}W{{/is_warning}}E{{/is_alert}}tail'
+      const result = renderMonitorTemplate(tpl, {
+        conditionals: { is_alert: false, is_warning: true }
+      })
+
+      expect(result.rendered).toBe('tail')
+      expect(result.conditionalsResolved.is_alert).toBe(false)
+    })
+
+    it('renders nested conditional inside a variable substitution context', () => {
+      // Variable rendered alongside nested conditionals
+      const tpl =
+        'svc={{service}} {{#is_alert}}alert {{#is_no_data}}+nodata{{/is_no_data}}{{/is_alert}}'
+      const result = renderMonitorTemplate(tpl, {
+        variables: { service: 'web' },
+        conditionals: { is_alert: true, is_no_data: true }
+      })
+
+      expect(result.rendered).toBe('svc=web alert +nodata')
+      expect(result.variablesUsed).toEqual(['service'])
+      expect(result.conditionalsResolved).toEqual({ is_alert: true, is_no_data: true })
+    })
+  })
+
+  describe('unsupported syntax', () => {
+    it('throws EUNSUPPORTED_TEMPLATE_SYNTAX for {{#each items}}', () => {
+      expect(() => renderMonitorTemplate('{{#each items}}item{{/each}}', {})).toThrow(
+        /EUNSUPPORTED_TEMPLATE_SYNTAX/
+      )
+    })
+
+    it('throws EUNSUPPORTED_TEMPLATE_SYNTAX listing supported subset for each', () => {
+      try {
+        renderMonitorTemplate('{{#each rows}}x{{/each}}', {})
+        throw new Error('expected to throw')
+      } catch (err) {
+        expect(err).toBeInstanceOf(Error)
+        const msg = (err as Error).message
+        expect(msg).toContain('EUNSUPPORTED_TEMPLATE_SYNTAX')
+        expect(msg).toContain('is_alert')
+        expect(msg).toContain('is_warning')
+      }
+    })
+
+    it('throws EUNSUPPORTED_TEMPLATE_SYNTAX for {{> partial}}', () => {
+      expect(() => renderMonitorTemplate('hello {{> header}} world', {})).toThrow(
+        /EUNSUPPORTED_TEMPLATE_SYNTAX/
+      )
+    })
+
+    it('throws EUNSUPPORTED_TEMPLATE_SYNTAX for an unknown conditional block', () => {
+      // is_unknown is not part of the supported conditional set
+      expect(() => renderMonitorTemplate('{{#is_unknown}}x{{/is_unknown}}', {})).toThrow(
+        /EUNSUPPORTED_TEMPLATE_SYNTAX/
+      )
+    })
+  })
+
+  describe('return shape', () => {
+    it('returns all four fields even on a plain string template', () => {
+      const result = renderMonitorTemplate('plain text', {})
+
+      expect(result).toEqual({
+        rendered: 'plain text',
+        variablesUsed: [],
+        variablesMissing: [],
+        conditionalsResolved: {}
+      })
+    })
+
+    it('returns conditionalsResolved with every encountered conditional', () => {
+      const tpl =
+        '{{#is_alert}}A{{/is_alert}}{{^is_warning}}NW{{/is_warning}}{{#is_no_data}}N{{/is_no_data}}'
+      const result = renderMonitorTemplate(tpl, {
+        conditionals: { is_alert: true, is_warning: false, is_no_data: false }
+      })
+
+      expect(result.conditionalsResolved).toEqual({
+        is_alert: true,
+        is_warning: false,
+        is_no_data: false
+      })
+    })
+  })
+})

--- a/tests/utils/timezone.test.ts
+++ b/tests/utils/timezone.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateIanaZone,
+  formatLocal,
+  bucketHourOfDay,
+  bucketDayOfWeek,
+  bucketDayOfMonth
+} from '../../src/utils/timezone.js'
+
+describe('Timezone Utilities', () => {
+  describe('validateIanaZone', () => {
+    it('accepts UTC', () => {
+      expect(() => validateIanaZone('UTC')).not.toThrow()
+    })
+
+    it('accepts Europe/Paris', () => {
+      expect(() => validateIanaZone('Europe/Paris')).not.toThrow()
+    })
+
+    it('accepts America/New_York', () => {
+      expect(() => validateIanaZone('America/New_York')).not.toThrow()
+    })
+
+    it('rejects empty string with EINVALID_TIMEZONE', () => {
+      expect(() => validateIanaZone('')).toThrow(/EINVALID_TIMEZONE/)
+    })
+
+    it('rejects non-string with EINVALID_TIMEZONE', () => {
+      // @ts-expect-error — testing runtime guard against non-string input
+      expect(() => validateIanaZone(123)).toThrow(/EINVALID_TIMEZONE/)
+    })
+
+    it('rejects unknown zone with EINVALID_TIMEZONE', () => {
+      expect(() => validateIanaZone('NotARealZone')).toThrow(/EINVALID_TIMEZONE/)
+    })
+
+    it('rejects broken EST5EDT-broken with EINVALID_TIMEZONE', () => {
+      expect(() => validateIanaZone('EST5EDT-broken')).toThrow(/EINVALID_TIMEZONE/)
+    })
+
+    it('includes up to 3 suggestions for near-miss zones', () => {
+      let thrown: Error | undefined
+      try {
+        validateIanaZone('Europe/Pari')
+      } catch (err) {
+        thrown = err as Error
+      }
+      expect(thrown).toBeDefined()
+      expect(thrown?.message).toMatch(/EINVALID_TIMEZONE/)
+      // Should suggest Europe/Paris
+      expect(thrown?.message).toMatch(/Europe\/Paris/)
+      // Extract the suggestion list — everything after "Did you mean: ".
+      const suggestionMatch = thrown?.message.match(/Did you mean: (.+?)\?/)
+      expect(suggestionMatch).not.toBeNull()
+      const suggestions = (suggestionMatch?.[1] ?? '').split(',').map((s) => s.trim())
+      expect(suggestions.length).toBeLessThanOrEqual(3)
+      expect(suggestions.length).toBeGreaterThan(0)
+    })
+
+    it('does not throw a generic Error message — uses EINVALID_TIMEZONE prefix', () => {
+      try {
+        validateIanaZone('xyz')
+      } catch (err) {
+        expect((err as Error).message.startsWith('EINVALID_TIMEZONE')).toBe(true)
+      }
+    })
+  })
+
+  describe('formatLocal', () => {
+    it('returns ISO 8601 with offset for Europe/Paris in summer (CEST = +02:00)', () => {
+      // 2026-05-14T07:15:00Z → 09:15 in Paris (CEST)
+      const ms = Date.UTC(2026, 4, 14, 7, 15, 0)
+      expect(formatLocal(ms, 'Europe/Paris')).toBe('2026-05-14T09:15:00+02:00')
+    })
+
+    it('returns ISO 8601 with offset for Europe/Paris in winter (CET = +01:00)', () => {
+      // 2026-01-14T07:15:00Z → 08:15 in Paris (CET)
+      const ms = Date.UTC(2026, 0, 14, 7, 15, 0)
+      expect(formatLocal(ms, 'Europe/Paris')).toBe('2026-01-14T08:15:00+01:00')
+    })
+
+    it('returns ISO 8601 with Z for UTC zone', () => {
+      const ms = Date.UTC(2026, 4, 14, 7, 15, 0)
+      const out = formatLocal(ms, 'UTC')
+      // Either Z or +00:00 is acceptable ISO 8601; we choose Z for UTC.
+      expect(out).toBe('2026-05-14T07:15:00Z')
+    })
+
+    it('returns ISO 8601 with negative offset for America/New_York in summer (EDT = -04:00)', () => {
+      // 2026-07-14T16:15:00Z → 12:15 in NY (EDT)
+      const ms = Date.UTC(2026, 6, 14, 16, 15, 0)
+      expect(formatLocal(ms, 'America/New_York')).toBe('2026-07-14T12:15:00-04:00')
+    })
+
+    it('throws EINVALID_TIMEZONE for invalid zone', () => {
+      const ms = Date.UTC(2026, 4, 14, 7, 15, 0)
+      expect(() => formatLocal(ms, 'NotARealZone')).toThrow(/EINVALID_TIMEZONE/)
+    })
+  })
+
+  describe('bucketHourOfDay', () => {
+    it('returns 0..23 inclusive', () => {
+      const ms = Date.UTC(2026, 4, 14, 0, 0, 0)
+      const hour = bucketHourOfDay(ms, 'UTC')
+      expect(hour).toBeGreaterThanOrEqual(0)
+      expect(hour).toBeLessThanOrEqual(23)
+    })
+
+    it('returns hour 3 for 2026-03-29T01:30:00Z in Europe/Paris (DST spring-forward)', () => {
+      const ms = Date.parse('2026-03-29T01:30:00Z')
+      // At 01:00 UTC on 2026-03-29 in Paris, clocks jump from 02:00 to 03:00.
+      // So 01:30 UTC = 03:30 local (CEST = +02:00).
+      expect(bucketHourOfDay(ms, 'Europe/Paris')).toBe(3)
+    })
+
+    it('returns hour 2 for 2026-10-25T01:30:00Z in Europe/Paris (DST fall-back)', () => {
+      const ms = Date.parse('2026-10-25T01:30:00Z')
+      // At 01:00 UTC on 2026-10-25 in Paris, clocks fall back from 03:00 to 02:00.
+      // So 01:30 UTC = 02:30 local (CET = +01:00), bucketed as hour 2.
+      expect(bucketHourOfDay(ms, 'Europe/Paris')).toBe(2)
+    })
+
+    it('returns 7 for 2026-05-14T07:15:00Z in UTC', () => {
+      const ms = Date.parse('2026-05-14T07:15:00Z')
+      expect(bucketHourOfDay(ms, 'UTC')).toBe(7)
+    })
+
+    it('returns 9 for 2026-05-14T07:15:00Z in Europe/Paris (CEST)', () => {
+      const ms = Date.parse('2026-05-14T07:15:00Z')
+      expect(bucketHourOfDay(ms, 'Europe/Paris')).toBe(9)
+    })
+
+    it('throws EINVALID_TIMEZONE for invalid zone', () => {
+      const ms = Date.parse('2026-05-14T07:15:00Z')
+      expect(() => bucketHourOfDay(ms, 'NotARealZone')).toThrow(/EINVALID_TIMEZONE/)
+    })
+  })
+
+  describe('bucketDayOfWeek', () => {
+    it('returns 4 (Thursday) for 2026-05-14T12:00:00Z in UTC (per design: 0=Sunday..6=Saturday)', () => {
+      const ms = Date.parse('2026-05-14T12:00:00Z')
+      // 2026-05-14 is a Thursday → 4 (0=Sun,1=Mon,2=Tue,3=Wed,4=Thu,5=Fri,6=Sat)
+      expect(bucketDayOfWeek(ms, 'UTC')).toBe(4)
+    })
+
+    it('returns 0 (Sunday) for a Sunday', () => {
+      // 2026-05-17 is a Sunday
+      const ms = Date.parse('2026-05-17T12:00:00Z')
+      expect(bucketDayOfWeek(ms, 'UTC')).toBe(0)
+    })
+
+    it('crosses day boundary at midnight in target zone (Paris-late vs UTC-early)', () => {
+      // 2026-05-14T23:30:00Z = 2026-05-15T01:30 Paris (Friday) but Thursday in UTC
+      const ms = Date.parse('2026-05-14T23:30:00Z')
+      expect(bucketDayOfWeek(ms, 'UTC')).toBe(4) // Thursday
+      expect(bucketDayOfWeek(ms, 'Europe/Paris')).toBe(5) // Friday
+    })
+
+    it('crosses day boundary in other direction (NY-late vs UTC-early)', () => {
+      // 2026-05-14T03:00:00Z = 2026-05-13T23:00 NY (Wednesday) but Thursday UTC
+      const ms = Date.parse('2026-05-14T03:00:00Z')
+      expect(bucketDayOfWeek(ms, 'UTC')).toBe(4) // Thursday
+      expect(bucketDayOfWeek(ms, 'America/New_York')).toBe(3) // Wednesday
+    })
+
+    it('throws EINVALID_TIMEZONE for invalid zone', () => {
+      const ms = Date.parse('2026-05-14T07:15:00Z')
+      expect(() => bucketDayOfWeek(ms, 'NotARealZone')).toThrow(/EINVALID_TIMEZONE/)
+    })
+  })
+
+  describe('bucketDayOfMonth', () => {
+    it('returns 14 for 2026-05-14T12:00:00Z in UTC', () => {
+      const ms = Date.parse('2026-05-14T12:00:00Z')
+      expect(bucketDayOfMonth(ms, 'UTC')).toBe(14)
+    })
+
+    it('crosses day boundary at midnight in Europe/Paris (UTC late-night → next day Paris)', () => {
+      // 2026-05-14T23:30:00Z = 01:30 Paris on 2026-05-15
+      const ms = Date.parse('2026-05-14T23:30:00Z')
+      expect(bucketDayOfMonth(ms, 'UTC')).toBe(14)
+      expect(bucketDayOfMonth(ms, 'Europe/Paris')).toBe(15)
+    })
+
+    it('crosses day boundary in America/New_York (UTC early-morning → previous day NY)', () => {
+      // 2026-05-14T03:00:00Z = 23:00 NY on 2026-05-13
+      const ms = Date.parse('2026-05-14T03:00:00Z')
+      expect(bucketDayOfMonth(ms, 'UTC')).toBe(14)
+      expect(bucketDayOfMonth(ms, 'America/New_York')).toBe(13)
+    })
+
+    it('returns 1 for the first of a month in target zone', () => {
+      // 2026-05-31T23:30Z = 01:30 Paris on 2026-06-01
+      const ms = Date.parse('2026-05-31T23:30:00Z')
+      expect(bucketDayOfMonth(ms, 'Europe/Paris')).toBe(1)
+    })
+
+    it('throws EINVALID_TIMEZONE for invalid zone', () => {
+      const ms = Date.parse('2026-05-14T07:15:00Z')
+      expect(() => bucketDayOfMonth(ms, 'NotARealZone')).toThrow(/EINVALID_TIMEZONE/)
+    })
+  })
+})


### PR DESCRIPTION
Implements `events-dx-improvements` spec — addresses the larger items from issue #49.

## Summary

Seven DX features distilled from a 4-hour Datadog investigation session:

| # | Surface | Feature |
|---|---|---|
| 1 | `monitors.create` | `dry_run: true` routes to `validateMonitor` instead of `createMonitor`; allowed in read-only |
| 2 | `metrics.query` | `meta.rollup{Requested,Effective,Overridden}` exposes silent server-side downsampling |
| 3 | `events.histogram` | New action — server-side bucketing by `hour_of_day` / `day_of_week` / `day_of_month` in any IANA timezone (DST-safe) |
| 4 | `events` + `monitors` | Optional `timezone` adds `*Local` ISO 8601 annotations to every timestamp |
| 5 | `events.search` | Zero-result responses include `diagnostics` array (`UNINDEXED_TAG_PREFIX`, `NARROW_TIME_RANGE`, `RESTRICTIVE_SOURCE_FILTER`) |
| 6 | `monitors.test_notification` | Returns `ENOT_SUPPORTED` — Datadog has no public REST endpoint for this (OQ-1 closed via API spec audit) |
| 7 | `monitors.preview` | New action — render a monitor template (inline `message` or by `id`) with `context` of variables + conditionals; supports the 6 documented Datadog conditionals |

## Architecture additions

- `src/utils/timezone.ts` — `validateIanaZone`, `formatLocal`, `bucketHourOfDay`/`Week`/`Month` (DST-safe via `Intl.DateTimeFormat`, no manual offset math)
- `src/utils/templatePreview.ts` — `renderMonitorTemplate` supporting Datadog's Mustache subset (variables + 6 conditionals); rejects `{{#each}}`/partials with `EUNSUPPORTED_TEMPLATE_SYNTAX`
- `src/schema/events.ts` — `EventsDiagnosticCode` enum exposed via the schema tool
- `src/config/schema.ts` — `limits.maxEventsForHistogram` (default 5000, env `MCP_MAX_EVENTS_HISTOGRAM`)

## Backward compatibility

- All response-shape additions are opt-in: `timezone` omitted → no `*Local` fields; `dry_run` omitted → existing `createMonitor` path; `diagnostics` only present on zero-result `events.search`.
- New input parameters (`timezone`, `dry_run`, `bucket_by`, etc.) are all optional.
- Existing tests pass unmodified (1124 → 1146 = +22 net new tests across this spec, of which ~17 are new behavior, ~5 are regression guards).

## Notable findings

- **OQ-1 closed**: Datadog's public OpenAPI v1+v2 specs (audited via docs.datadoghq.com) expose no monitor test-notification endpoint. `monitors.test_notification` returns `ENOT_SUPPORTED` with a documentation pointer rather than silently failing.
- **DST in JavaScript**: `Intl.DateTimeFormat` is the only safe way to handle timezones — manual offset arithmetic breaks across spring-forward / fall-back transitions. The timezone util enforces this.

## Test plan

- [x] `npm run lint` (0 errors, 3 pre-existing `any` warnings in `topEventsV2`)
- [x] `npm run typecheck`
- [x] `npm test -- --run` (1146/1146 across 65 files)
- [x] `npm run build`