### PR TITLE
fix(slos): include query, monitorIds, monitorTags, groups on get/list (#55)

### DIFF
--- a/src/tools/slos.ts
+++ b/src/tools/slos.ts
@@ -57,10 +57,7 @@ interface SloSummary {
   overallStatus: SloStatusByTimeframe[]
   createdAt: string
   modifiedAt: string
-  // SLO definition fields needed to round-trip update calls (see issue #55).
-  // Datadog PUT /api/v1/slo/{id} requires `query` for metric SLOs and
-  // `monitor_ids` for monitor SLOs; stripping them here forced callers to
-  // re-supply the same query they could not retrieve from get.
+  // Required by PUT /api/v1/slo/{id}; field presence depends on SLO type.
   query?: SloQueryProjection
   monitorIds?: number[]
   monitorTags?: string[]

--- a/src/tools/slos.ts
+++ b/src/tools/slos.ts
@@ -35,6 +35,11 @@ interface SloStatusByTimeframe {
   timeframe: string
 }
 
+export interface SloQueryProjection {
+  numerator: string
+  denominator: string
+}
+
 interface SloSummary {
   id: string
   name: string
@@ -52,11 +57,19 @@ interface SloSummary {
   overallStatus: SloStatusByTimeframe[]
   createdAt: string
   modifiedAt: string
+  // SLO definition fields needed to round-trip update calls (see issue #55).
+  // Datadog PUT /api/v1/slo/{id} requires `query` for metric SLOs and
+  // `monitor_ids` for monitor SLOs; stripping them here forced callers to
+  // re-supply the same query they could not retrieve from get.
+  query?: SloQueryProjection
+  monitorIds?: number[]
+  monitorTags?: string[]
+  groups?: string[]
 }
 
 export function formatSlo(s: v1.ServiceLevelObjective | v1.SLOResponseData): SloSummary {
   const primaryThreshold = s.thresholds?.[0]
-  return {
+  const summary: SloSummary = {
     id: s.id ?? '',
     name: s.name ?? '',
     description: s.description ?? null,
@@ -74,12 +87,27 @@ export function formatSlo(s: v1.ServiceLevelObjective | v1.SLOResponseData): Slo
     createdAt: s.createdAt ? new Date(s.createdAt * 1000).toISOString() : '',
     modifiedAt: s.modifiedAt ? new Date(s.modifiedAt * 1000).toISOString() : ''
   }
+
+  if (s.query?.numerator && s.query.denominator) {
+    summary.query = { numerator: s.query.numerator, denominator: s.query.denominator }
+  }
+  if (Array.isArray(s.monitorIds) && s.monitorIds.length > 0) {
+    summary.monitorIds = s.monitorIds
+  }
+  if (Array.isArray(s.monitorTags) && s.monitorTags.length > 0) {
+    summary.monitorTags = s.monitorTags
+  }
+  if (Array.isArray(s.groups) && s.groups.length > 0) {
+    summary.groups = s.groups
+  }
+
+  return summary
 }
 
 export function formatSearchSlo(slo: SearchServiceLevelObjective): SloSummary {
   const attrs = slo.data?.attributes
   const primaryThreshold = attrs?.thresholds?.[0]
-  return {
+  const summary: SloSummary = {
     id: slo.data?.id ?? '',
     name: attrs?.name ?? '',
     description: attrs?.description ?? null,
@@ -103,6 +131,19 @@ export function formatSearchSlo(slo: SearchServiceLevelObjective): SloSummary {
     createdAt: attrs?.createdAt ? new Date(attrs.createdAt * 1000).toISOString() : '',
     modifiedAt: attrs?.modifiedAt ? new Date(attrs.modifiedAt * 1000).toISOString() : ''
   }
+
+  // Round-trip parity with formatSlo (issue #55) — search response omits monitorTags.
+  if (attrs?.query?.numerator && attrs.query.denominator) {
+    summary.query = { numerator: attrs.query.numerator, denominator: attrs.query.denominator }
+  }
+  if (Array.isArray(attrs?.monitorIds) && attrs.monitorIds.length > 0) {
+    summary.monitorIds = attrs.monitorIds
+  }
+  if (Array.isArray(attrs?.groups) && attrs.groups.length > 0) {
+    summary.groups = attrs.groups
+  }
+
+  return summary
 }
 
 /**

--- a/src/tools/slos.ts
+++ b/src/tools/slos.ts
@@ -35,7 +35,7 @@ interface SloStatusByTimeframe {
   timeframe: string
 }
 
-export interface SloQueryProjection {
+interface SloQueryProjection {
   numerator: string
   denominator: string
 }

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -572,6 +572,10 @@ export const slos = {
         type: 'metric',
         thresholds: [{ target: 99.9, warning: 99.95, timeframe: '30d' }],
         tags: ['service:api', 'env:production'],
+        query: {
+          numerator: 'sum:requests.success{service:api}.as_count()',
+          denominator: 'sum:requests.total{service:api}.as_count()'
+        },
         overall_status: [{ sli_value: 99.95, error_budget_remaining: 75.5, state: 'OK' }],
         created_at: 1704067200,
         modified_at: 1705276800
@@ -583,6 +587,7 @@ export const slos = {
         type: 'monitor',
         thresholds: [{ target: 99.5, timeframe: '7d' }],
         tags: ['service:payments', 'env:production'],
+        monitor_ids: [12345, 12346],
         overall_status: [{ sli_value: 98.2, error_budget_remaining: -26.0, state: 'breached' }],
         created_at: 1704153600,
         modified_at: 1705363200

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -603,6 +603,11 @@ export const slos = {
                 slo_type: 'metric',
                 all_tags: ['service:api', 'env:production'],
                 thresholds: [{ target: 99.9, warning: 99.95, timeframe: '30d' }],
+                query: {
+                  numerator: 'sum:requests.success{service:api}.as_count()',
+                  denominator: 'sum:requests.total{service:api}.as_count()'
+                },
+                groups: ['service:api'],
                 status: {
                   sli: 99.95,
                   error_budget_remaining: 75.5,
@@ -632,6 +637,7 @@ export const slos = {
                 slo_type: 'monitor',
                 all_tags: ['service:payments', 'env:production'],
                 thresholds: [{ target: 99.5, timeframe: '7d' }],
+                monitor_ids: [12345, 12346],
                 status: {
                   sli: 98.2,
                   error_budget_remaining: -26.0,
@@ -665,7 +671,28 @@ export const slos = {
       tags: ['service:api', 'env:production'],
       overall_status: [{ sli_value: 99.95, error_budget_remaining: 75.5, state: 'OK' }],
       created_at: 1704067200,
-      modified_at: 1705276800
+      modified_at: 1705276800,
+      query: {
+        numerator: 'sum:requests.success{service:api}.as_count()',
+        denominator: 'sum:requests.total{service:api}.as_count()'
+      },
+      groups: ['service:api', 'service:gateway']
+    }
+  },
+  // Monitor-based SLO (slo-002) — used for monitor_ids/monitor_tags round-trip tests.
+  singleMonitorBased: {
+    data: {
+      id: 'slo-002',
+      name: 'Payment Processing Latency',
+      description: 'P99 latency under 500ms',
+      type: 'monitor',
+      thresholds: [{ target: 99.5, timeframe: '7d' }],
+      tags: ['service:payments', 'env:production'],
+      overall_status: [{ sli_value: 98.2, error_budget_remaining: -26.0, state: 'breached' }],
+      created_at: 1704153600,
+      modified_at: 1705363200,
+      monitor_ids: [12345, 12346],
+      monitor_tags: ['team:payments', 'tier:p99']
     }
   },
   history: {

--- a/tests/tools/slos.test.ts
+++ b/tests/tools/slos.test.ts
@@ -153,6 +153,22 @@ describe('SLOs Tool', () => {
       expect(result.slos[0].status.sli).toBeNull()
     })
 
+    it('should project query and monitorIds via the ids/listSLOs path', async () => {
+      server.use(
+        http.get(endpoints.listSlos, () => {
+          return jsonResponse(fixtures.list)
+        })
+      )
+
+      const result = await listSlos(api, { ids: ['slo-001'] }, defaultLimits)
+
+      expect(result.slos[0].query).toEqual({
+        numerator: 'sum:requests.success{service:api}.as_count()',
+        denominator: 'sum:requests.total{service:api}.as_count()'
+      })
+      expect(result.slos[1].monitorIds).toEqual([12345, 12346])
+    })
+
     it('should handle 401 unauthorized error', async () => {
       server.use(
         http.get(endpoints.searchSlos, () => {

--- a/tests/tools/slos.test.ts
+++ b/tests/tools/slos.test.ts
@@ -67,6 +67,29 @@ describe('SLOs Tool', () => {
       expect(result.slos[1].overallStatus[0].timeframe).toBe('7d')
     })
 
+    it('should project query/monitorIds/groups via search response (issue #55)', async () => {
+      server.use(
+        http.get(endpoints.searchSlos, () => {
+          return jsonResponse(fixtures.search)
+        })
+      )
+
+      const result = await listSlos(api, {}, defaultLimits)
+
+      // metric SLO carries query + groups
+      expect(result.slos[0].query).toEqual({
+        numerator: 'sum:requests.success{service:api}.as_count()',
+        denominator: 'sum:requests.total{service:api}.as_count()'
+      })
+      expect(result.slos[0].groups).toEqual(['service:api'])
+      expect(result.slos[0].monitorIds).toBeUndefined()
+
+      // monitor SLO carries monitorIds only (search response omits monitor_tags)
+      expect(result.slos[1].monitorIds).toEqual([12345, 12346])
+      expect(result.slos[1].query).toBeUndefined()
+      expect(result.slos[1].groups).toBeUndefined()
+    })
+
     it('should filter SLOs by tags via search query', async () => {
       server.use(
         http.get(endpoints.searchSlos, ({ request }) => {
@@ -179,6 +202,64 @@ describe('SLOs Tool', () => {
 
       expect(result.slo.id).toBe('slo-001')
       expect(result.slo.name).toBe('API Availability')
+    })
+
+    it('should project query for metric SLOs so update can round-trip (issue #55)', async () => {
+      server.use(
+        http.get(endpoints.getSlo('slo-001'), () => {
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      const result = await getSlo(api, 'slo-001')
+
+      expect(result.slo.query).toEqual({
+        numerator: 'sum:requests.success{service:api}.as_count()',
+        denominator: 'sum:requests.total{service:api}.as_count()'
+      })
+      expect(result.slo.groups).toEqual(['service:api', 'service:gateway'])
+      // monitorIds is only present on monitor SLOs.
+      expect(result.slo.monitorIds).toBeUndefined()
+    })
+
+    it('should project monitorIds and monitorTags for monitor SLOs (issue #55)', async () => {
+      server.use(
+        http.get(endpoints.getSlo('slo-002'), () => {
+          return jsonResponse(fixtures.singleMonitorBased)
+        })
+      )
+
+      const result = await getSlo(api, 'slo-002')
+
+      expect(result.slo.monitorIds).toEqual([12345, 12346])
+      expect(result.slo.monitorTags).toEqual(['team:payments', 'tier:p99'])
+      // query is only present on metric SLOs.
+      expect(result.slo.query).toBeUndefined()
+    })
+
+    it('should omit round-trip fields when Datadog response does not include them', async () => {
+      server.use(
+        http.get(endpoints.getSlo('slo-bare'), () => {
+          return jsonResponse({
+            data: {
+              id: 'slo-bare',
+              name: 'Bare SLO',
+              type: 'metric',
+              thresholds: [{ target: 99, timeframe: '30d' }],
+              tags: [],
+              created_at: 1704067200,
+              modified_at: 1705276800
+            }
+          })
+        })
+      )
+
+      const result = await getSlo(api, 'slo-bare')
+
+      expect(result.slo.query).toBeUndefined()
+      expect(result.slo.monitorIds).toBeUndefined()
+      expect(result.slo.groups).toBeUndefined()
+      expect(result.slo.monitorTags).toBeUndefined()
     })
 
     it('should handle 404 not found error', async () => {


### PR DESCRIPTION
Closes #55.

## Summary

Datadog GET `/api/v1/slo/{id}` returns `query` (numerator/denominator), `monitorIds`, `monitorTags`, `groups` — but the MCP layer was stripping them. Datadog's PUT endpoint requires these same fields, so callers couldn't read an SLO, mutate one field, and write it back. Tag cleanup, threshold tuning, IaC drift checks all broken.

## Changes

\`formatSlo\` and \`formatSearchSlo\` now project:
- \`query\` (numerator/denominator) for metric SLOs
- \`monitorIds\` for monitor SLOs
- \`monitorTags\` for monitor SLOs (single-get only; search response omits it)
- \`groups\` for grouped SLOs

All four are optional and only emitted when present, so the change is backward compatible.

## Tests

3 new tests covering metric/monitor/bare round-trip in \`slos.test.ts\`.

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test -- --run\`
- [x] \`npm run build\`