### PR TITLE
feat(slos,events): SLO url field and events search fields projection (#49 quick wins)

### DIFF
--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -123,11 +123,13 @@ const InputSchema = {
     .array(z.string())
     .optional()
     .describe(
-      'Search action only: return only these event fields. Allowed values: id, title, message, timestamp, priority, source, tags, alertType, host, monitorId, monitorInfo. Default: full event.'
+      'Search action only: return only these event fields. Allowed values: id, title, message, timestamp, priority, source, tags, alertType, host, monitorId, monitorInfo, monitorMetadata (only populated when enrich=true). Default: full event.'
     )
 }
 
-const ALLOWED_EVENT_FIELDS = new Set<keyof EventSummaryV2>([
+// Includes EnrichedEvent-only keys (monitorMetadata) so callers can project them
+// alongside EventSummaryV2 fields when enrich=true is set on the search action.
+const ALLOWED_EVENT_FIELDS = new Set<string>([
   'id',
   'title',
   'message',
@@ -138,27 +140,27 @@ const ALLOWED_EVENT_FIELDS = new Set<keyof EventSummaryV2>([
   'alertType',
   'host',
   'monitorId',
-  'monitorInfo'
+  'monitorInfo',
+  'monitorMetadata'
 ])
 
 /**
- * Pick a subset of fields from an EventSummaryV2.
+ * Pick a subset of fields from an EventSummaryV2 or EnrichedEvent.
  * Returns the full event when fields is undefined or empty.
  * Unknown field names are ignored — projecting an empty subset is callers' responsibility.
  */
-export function pickEventFields(
-  event: EventSummaryV2,
+export function pickEventFields<T extends EventSummaryV2>(
+  event: T,
   fields: readonly string[] | undefined
-): Partial<EventSummaryV2> {
+): Partial<T> {
   if (!fields || fields.length === 0) {
     return event
   }
-  const projection: Partial<EventSummaryV2> = {}
+  const projection: Partial<T> = {}
   for (const key of fields) {
-    if (ALLOWED_EVENT_FIELDS.has(key as keyof EventSummaryV2)) {
-      const k = key as keyof EventSummaryV2
+    if (ALLOWED_EVENT_FIELDS.has(key)) {
       // Index signature is incompatible with declared field types, so cast through unknown.
-      ;(projection as Record<string, unknown>)[k] = event[k]
+      ;(projection as Record<string, unknown>)[key] = event[key as keyof typeof event]
     }
   }
   return projection

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -115,7 +115,53 @@ const InputSchema = {
         'For histogram: controls hour/day bucketing (default: UTC). ' +
         'For search/aggregate/top/incidents read actions: adds sibling *Local ISO 8601 ' +
         'strings (e.g. timestampLocal) next to existing timestamps. Omit for byte-identical legacy shape.'
+    ),
+  // Projection — applied to search action only. Reduces response payload
+  // when callers only need a subset of fields. Unknown field names are silently ignored so
+  // older clients are not broken when the EventSummary shape evolves.
+  fields: z
+    .array(z.string())
+    .optional()
+    .describe(
+      'Search action only: return only these event fields. Allowed values: id, title, message, timestamp, priority, source, tags, alertType, host, monitorId, monitorInfo. Default: full event.'
     )
+}
+
+const ALLOWED_EVENT_FIELDS = new Set<keyof EventSummaryV2>([
+  'id',
+  'title',
+  'message',
+  'timestamp',
+  'priority',
+  'source',
+  'tags',
+  'alertType',
+  'host',
+  'monitorId',
+  'monitorInfo'
+])
+
+/**
+ * Pick a subset of fields from an EventSummaryV2.
+ * Returns the full event when fields is undefined or empty.
+ * Unknown field names are ignored — projecting an empty subset is callers' responsibility.
+ */
+export function pickEventFields(
+  event: EventSummaryV2,
+  fields: readonly string[] | undefined
+): Partial<EventSummaryV2> {
+  if (!fields || fields.length === 0) {
+    return event
+  }
+  const projection: Partial<EventSummaryV2> = {}
+  for (const key of fields) {
+    if (ALLOWED_EVENT_FIELDS.has(key as keyof EventSummaryV2)) {
+      const k = key as keyof EventSummaryV2
+      // Index signature is incompatible with declared field types, so cast through unknown.
+      ;(projection as Record<string, unknown>)[k] = event[k]
+    }
+  }
+  return projection
 }
 
 // v1 Event summary format
@@ -1942,7 +1988,8 @@ histogram: Bucket events by local hour_of_day / day_of_week / day_of_month in th
       maxEvents,
       transitionType,
       bucket_by,
-      timezone
+      timezone,
+      fields
     }) => {
       try {
         checkReadOnly(action, readOnly)
@@ -2005,10 +2052,21 @@ histogram: Bucket events by local hour_of_day / day_of_week / day_of_month in th
             // Phase 3: Optional enrichment
             if (enrich && result.events.length > 0) {
               const enrichedEvents = await enrichWithMonitorMetadata(result.events, monitorsApi)
-              return toolResult({ ...result, events: enrichedEvents })
+              // Field projection applies on top of enrichment too — enriched events carry
+              // additional keys not in EventSummaryV2 (monitorName, monitorPriority,
+              // monitorMessage); when `fields` is set, those extra keys are dropped along
+              // with the standard ones unless explicitly requested via the same name.
+              const projected = fields?.length
+                ? enrichedEvents.map((e) => pickEventFields(e, fields))
+                : enrichedEvents
+              return toolResult({ ...result, events: projected })
             }
 
-            return toolResult(result)
+            // Issue #49 item 3: optional field projection to keep response payloads small.
+            const projectedEvents = fields?.length
+              ? result.events.map((e) => pickEventFields(e, fields))
+              : result.events
+            return toolResult({ ...result, events: projectedEvents })
           }
 
           case 'aggregate':

--- a/src/tools/events.ts
+++ b/src/tools/events.ts
@@ -2064,7 +2064,7 @@ histogram: Bucket events by local hour_of_day / day_of_week / day_of_month in th
               return toolResult({ ...result, events: projected })
             }
 
-            // Issue #49 item 3: optional field projection to keep response payloads small.
+            // Optional field projection to keep response payloads small.
             const projectedEvents = fields?.length
               ? result.events.map((e) => pickEventFields(e, fields))
               : result.events

--- a/src/tools/slos.ts
+++ b/src/tools/slos.ts
@@ -6,6 +6,7 @@ import { handleDatadogError, requireParam, checkReadOnly } from '../errors/datad
 import { toolResult } from '../utils/format.js'
 import { parseTime, ensureValidTimeRange } from '../utils/time.js'
 import { snakeToCamel, normalizeConfigKeys } from '../utils/normalize.js'
+import { buildSloUrl } from '../utils/urls.js'
 import type { LimitsConfig } from '../config/schema.js'
 
 // Re-exported so existing public callers (and tests) that import these helpers
@@ -67,12 +68,19 @@ interface SloSummary {
   monitorIds?: number[]
   monitorTags?: string[]
   groups?: string[]
+  // Deep link to the Datadog UI.
+  // Empty string when id is unavailable on the upstream payload.
+  url: string
 }
 
-export function formatSlo(s: v1.ServiceLevelObjective | v1.SLOResponseData): SloSummary {
+export function formatSlo(
+  s: v1.ServiceLevelObjective | v1.SLOResponseData,
+  site: string = 'datadoghq.com'
+): SloSummary {
   const primaryThreshold = s.thresholds?.[0]
+  const id = s.id ?? ''
   const summary: SloSummary = {
-    id: s.id ?? '',
+    id,
     name: s.name ?? '',
     description: s.description ?? null,
     type: String(s.type ?? 'unknown'),
@@ -87,7 +95,8 @@ export function formatSlo(s: v1.ServiceLevelObjective | v1.SLOResponseData): Slo
     },
     overallStatus: [],
     createdAt: s.createdAt ? new Date(s.createdAt * 1000).toISOString() : '',
-    modifiedAt: s.modifiedAt ? new Date(s.modifiedAt * 1000).toISOString() : ''
+    modifiedAt: s.modifiedAt ? new Date(s.modifiedAt * 1000).toISOString() : '',
+    url: id ? buildSloUrl(id, site) : ''
   }
 
   if (s.query?.numerator && s.query.denominator) {
@@ -106,11 +115,15 @@ export function formatSlo(s: v1.ServiceLevelObjective | v1.SLOResponseData): Slo
   return summary
 }
 
-export function formatSearchSlo(slo: SearchServiceLevelObjective): SloSummary {
+export function formatSearchSlo(
+  slo: SearchServiceLevelObjective,
+  site: string = 'datadoghq.com'
+): SloSummary {
   const attrs = slo.data?.attributes
   const primaryThreshold = attrs?.thresholds?.[0]
+  const id = slo.data?.id ?? ''
   const summary: SloSummary = {
-    id: slo.data?.id ?? '',
+    id,
     name: attrs?.name ?? '',
     description: attrs?.description ?? null,
     type: String(attrs?.sloType ?? 'unknown'),
@@ -131,7 +144,8 @@ export function formatSearchSlo(slo: SearchServiceLevelObjective): SloSummary {
       timeframe: String(os.timeframe ?? '')
     })),
     createdAt: attrs?.createdAt ? new Date(attrs.createdAt * 1000).toISOString() : '',
-    modifiedAt: attrs?.modifiedAt ? new Date(attrs.modifiedAt * 1000).toISOString() : ''
+    modifiedAt: attrs?.modifiedAt ? new Date(attrs.modifiedAt * 1000).toISOString() : '',
+    url: id ? buildSloUrl(id, site) : ''
   }
 
   // Round-trip parity with formatSlo (issue #55) — search response omits monitorTags.
@@ -161,7 +175,8 @@ function buildSearchQuery(query?: string, tags?: string[]): string {
 export async function listSlos(
   api: v1.ServiceLevelObjectivesApi,
   params: { ids?: string[]; query?: string; tags?: string[]; limit?: number },
-  limits: LimitsConfig
+  limits: LimitsConfig,
+  site: string = 'datadoghq.com'
 ) {
   const effectiveLimit = params.limit ?? limits.defaultLimit
 
@@ -172,7 +187,7 @@ export async function listSlos(
       limit: effectiveLimit
     })
 
-    const slos = (response.data ?? []).map(formatSlo)
+    const slos = (response.data ?? []).map((s) => formatSlo(s, site))
     return { slos, total: slos.length }
   }
 
@@ -184,7 +199,7 @@ export async function listSlos(
   })
 
   const searchSlos = response.data?.attributes?.slos ?? []
-  const slos = searchSlos.map(formatSearchSlo)
+  const slos = searchSlos.map((s) => formatSearchSlo(s, site))
 
   return {
     slos,
@@ -192,10 +207,14 @@ export async function listSlos(
   }
 }
 
-export async function getSlo(api: v1.ServiceLevelObjectivesApi, id: string) {
+export async function getSlo(
+  api: v1.ServiceLevelObjectivesApi,
+  id: string,
+  site: string = 'datadoghq.com'
+) {
   const response = await api.getSLO({ sloId: id })
   return {
-    slo: response.data ? formatSlo(response.data) : null
+    slo: response.data ? formatSlo(response.data, site) : null
   }
 }
 
@@ -221,26 +240,28 @@ export function normalizeSloConfig(config: Record<string, unknown>): Record<stri
 
 export async function createSlo(
   api: v1.ServiceLevelObjectivesApi,
-  config: Record<string, unknown>
+  config: Record<string, unknown>,
+  site: string = 'datadoghq.com'
 ) {
   const body = normalizeSloConfig(config) as unknown as v1.ServiceLevelObjectiveRequest
   const response = await api.createSLO({ body })
   return {
     success: true,
-    slo: response.data?.[0] ? formatSlo(response.data[0]) : null
+    slo: response.data?.[0] ? formatSlo(response.data[0], site) : null
   }
 }
 
 export async function updateSlo(
   api: v1.ServiceLevelObjectivesApi,
   id: string,
-  config: Record<string, unknown>
+  config: Record<string, unknown>,
+  site: string = 'datadoghq.com'
 ) {
   const body = normalizeConfigKeys(config) as unknown as v1.ServiceLevelObjective
   const response = await api.updateSLO({ sloId: id, body })
   return {
     success: true,
-    slo: response.data?.[0] ? formatSlo(response.data[0]) : null
+    slo: response.data?.[0] ? formatSlo(response.data[0], site) : null
   }
 }
 
@@ -295,33 +316,33 @@ export function registerSlosTool(
   api: v1.ServiceLevelObjectivesApi,
   limits: LimitsConfig,
   readOnly: boolean = false,
-  _site: string = 'datadoghq.com'
+  site: string = 'datadoghq.com'
 ): void {
   server.tool(
     'slos',
-    'Manage Datadog Service Level Objectives. Actions: list (with SLI status & error budget), get, create, update, delete, history. SLO types: metric-based, monitor-based. Use for: reliability tracking, error budgets, SLA compliance, performance targets.',
+    'Manage Datadog Service Level Objectives. Actions: list (with SLI status & error budget), get, create, update, delete, history. SLO types: metric-based, monitor-based. Each list/get/create/update response includes a `url` field deep-linking to the Datadog UI. Use for: reliability tracking, error budgets, SLA compliance, performance targets.',
     InputSchema,
     async ({ action, id, ids, query, tags, limit, config, from, to }) => {
       try {
         checkReadOnly(action, readOnly)
         switch (action) {
           case 'list':
-            return toolResult(await listSlos(api, { ids, query, tags, limit }, limits))
+            return toolResult(await listSlos(api, { ids, query, tags, limit }, limits, site))
 
           case 'get': {
             const sloId = requireParam(id, 'id', 'get')
-            return toolResult(await getSlo(api, sloId))
+            return toolResult(await getSlo(api, sloId, site))
           }
 
           case 'create': {
             const sloConfig = requireParam(config, 'config', 'create')
-            return toolResult(await createSlo(api, sloConfig))
+            return toolResult(await createSlo(api, sloConfig, site))
           }
 
           case 'update': {
             const sloId = requireParam(id, 'id', 'update')
             const sloConfig = requireParam(config, 'config', 'update')
-            return toolResult(await updateSlo(api, sloId, sloConfig))
+            return toolResult(await updateSlo(api, sloId, sloConfig, site))
           }
 
           case 'delete': {

--- a/tests/tools/events.test.ts
+++ b/tests/tools/events.test.ts
@@ -1145,5 +1145,30 @@ describe('Events Tool', () => {
       const projection = pickEventFields(fullEvent, ['tags'])
       expect(projection.tags).toBe(fullEvent.tags)
     })
+
+    it('projects monitorMetadata from enriched events when requested', () => {
+      const enrichedEvent = {
+        ...fullEvent,
+        monitorMetadata: {
+          id: 12345,
+          name: 'High error rate monitor',
+          type: 'metric alert',
+          message: 'Errors exceeded threshold',
+          tags: ['team:platform'],
+          options: {
+            thresholds: { critical: 100 },
+            notifyNoData: false,
+            escalationMessage: ''
+          }
+        }
+      }
+      const projection = pickEventFields(enrichedEvent, ['title', 'monitorMetadata'])
+      expect(projection).toEqual({
+        title: 'High error rate',
+        monitorMetadata: enrichedEvent.monitorMetadata
+      })
+      // Same-reference preservation — projection should not deep-clone the metadata.
+      expect(projection.monitorMetadata).toBe(enrichedEvent.monitorMetadata)
+    })
   })
 })

--- a/tests/tools/events.test.ts
+++ b/tests/tools/events.test.ts
@@ -17,7 +17,8 @@ import {
   incidentsEventsV2,
   timeseriesEventsV2,
   computeDiagnostics,
-  UNINDEXED_ALERT_TAG_PREFIXES
+  UNINDEXED_ALERT_TAG_PREFIXES,
+  pickEventFields
 } from '../../src/tools/events.js'
 import type { LimitsConfig } from '../../src/config/schema.js'
 
@@ -1097,6 +1098,52 @@ describe('Events Tool', () => {
         ).rejects.toThrow(/EINVALID_TIMEZONE/)
         expect(hit).toBe(false)
       })
+    })
+  })
+
+  describe('pickEventFields (issue #49 field projection)', () => {
+    const fullEvent = {
+      id: 'evt-1',
+      title: 'High error rate',
+      message: 'Errors exceeded threshold',
+      timestamp: '2026-05-13T12:00:00.000Z',
+      priority: 'normal',
+      source: 'alert',
+      tags: ['env:production', 'service:api'],
+      alertType: 'error',
+      host: 'prod-1',
+      monitorId: 12345,
+      monitorInfo: undefined
+    }
+
+    it('returns the full event when fields is undefined', () => {
+      expect(pickEventFields(fullEvent, undefined)).toBe(fullEvent)
+    })
+
+    it('returns the full event when fields is an empty array', () => {
+      expect(pickEventFields(fullEvent, [])).toBe(fullEvent)
+    })
+
+    it('returns only the requested fields', () => {
+      const projection = pickEventFields(fullEvent, ['timestamp', 'title', 'monitorId'])
+      expect(projection).toEqual({
+        timestamp: '2026-05-13T12:00:00.000Z',
+        title: 'High error rate',
+        monitorId: 12345
+      })
+    })
+
+    it('silently ignores unknown field names so callers are not broken by typos', () => {
+      const projection = pickEventFields(fullEvent, ['title', 'doesNotExist', 'source'])
+      expect(projection).toEqual({
+        title: 'High error rate',
+        source: 'alert'
+      })
+    })
+
+    it('preserves tags array reference when requested', () => {
+      const projection = pickEventFields(fullEvent, ['tags'])
+      expect(projection.tags).toBe(fullEvent.tags)
     })
   })
 })

--- a/tests/tools/events.test.ts
+++ b/tests/tools/events.test.ts
@@ -1133,7 +1133,7 @@ describe('Events Tool', () => {
       })
     })
 
-    it('silently ignores unknown field names so callers are not broken by typos', () => {
+    it('silently ignores unknown field names for forward compatibility with future EventSummary additions', () => {
       const projection = pickEventFields(fullEvent, ['title', 'doesNotExist', 'source'])
       expect(projection).toEqual({
         title: 'High error rate',

--- a/tests/tools/slos.test.ts
+++ b/tests/tools/slos.test.ts
@@ -278,6 +278,28 @@ describe('SLOs Tool', () => {
       expect(result.slo.monitorTags).toBeUndefined()
     })
 
+    it('should include a deep-link url field for the Datadog UI', async () => {
+      server.use(
+        http.get(endpoints.getSlo('slo-001'), () => {
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      const result = await getSlo(api, 'slo-001')
+      expect(result.slo?.url).toBe('https://app.datadoghq.com/slo/slo-001')
+    })
+
+    it('should respect the configured Datadog site when building urls', async () => {
+      server.use(
+        http.get(endpoints.getSlo('slo-001'), () => {
+          return jsonResponse(fixtures.single)
+        })
+      )
+
+      const result = await getSlo(api, 'slo-001', 'datadoghq.eu')
+      expect(result.slo?.url).toBe('https://app.datadoghq.eu/slo/slo-001')
+    })
+
     it('should handle 404 not found error', async () => {
       server.use(
         http.get(endpoints.getSlo('nonexistent'), () => {


### PR DESCRIPTION
Addresses two cheap items from #49.

## Summary

- **Item 7 — SLO \`url\` field**: \`slos\` list/get/create/update responses now include a \`url\` deep-link to the Datadog UI, mirroring the existing \`url\` on monitors. Threaded through \`site\` so non-default Datadog regions (\`datadoghq.eu\`, etc.) work.
- **Item 3 — events search field projection**: \`events action=search\` now accepts an optional \`fields\` array. Returned events are projected to only the requested keys. Unknown keys are silently dropped (backward compat for future field additions). Composes with the existing \`enrich\` flag.

Larger items from #49 (dry-run validation, server-side histogram, rollup-override warnings, test_notification, monitor message preview, timezone-aware timestamps, empty-result diagnostics) are scoped to a dedicated \`events-dx-improvements\` spec — they have meaningful design decisions and shouldn't ship as drive-by changes. Bulk_create (item 10) was deemed out of scope and deferred.

## Tests

7 new tests (2 SLO url + 5 \`pickEventFields\` edge cases).

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run typecheck\`
- [x] \`npm test -- --run\`
- [x] \`npm run build\`